### PR TITLE
Some fixes of full autoconfiguration with software cam and fix for unicast http messages [reopened]

### DIFF
--- a/src/scam_capmt.c
+++ b/src/scam_capmt.c
@@ -93,7 +93,7 @@ int scam_send_capmt(mumudvb_channel_t *channel, int adapter)
     snprintf(serv_addr_un.sun_path, sizeof(serv_addr_un.sun_path), "/tmp/camd.socket");
     if (connect(channel->camd_socket, (const struct sockaddr *) &serv_addr_un, sizeof(serv_addr_un)) != 0)
     {
-	  log_message(log_module, MSG_ERROR,"Canot connect to /tmp/camd.socket for channel %s, Do you have OSCam running?\n", channel->name);
+	  log_message(log_module, MSG_ERROR,"cannot connect to /tmp/camd.socket for channel %s. Do you have OSCam running?\n", channel->name);
       channel->camd_socket = 0;
 	  return 1;
     }

--- a/src/scam_common.h
+++ b/src/scam_common.h
@@ -72,6 +72,7 @@ typedef struct scam_parameters_t{
   ca_descr_t ca_descr;
   ca_pid_t ca_pid;
   uint64_t ring_buffer_default_size,decsa_default_delay,send_default_delay;
+  char got_pid_t[1<<13];
 }scam_parameters_t;  
 
 

--- a/src/scam_getcw.c
+++ b/src/scam_getcw.c
@@ -116,8 +116,6 @@ static void *getcwthread_func(void* arg)
   extern int Interrupted; 
   unsigned char buff[sizeof(int) + sizeof(ca_descr_t)];
   int cRead, *request;
-
-  static char got_pid_t[2^13];
   char got_pid=0;
 	
   //Loop
@@ -157,8 +155,8 @@ static void *getcwthread_func(void* arg)
 			memcpy((&(scam_params->ca_pid)), &buff[sizeof(int)], sizeof(ca_pid_t));
 			log_message( log_module,  MSG_DEBUG, "Got CA_SET_PID request index: %d pid: %d\n",scam_params->ca_pid.index, scam_params->ca_pid.pid);
 			got_pid=0;
-			if (!got_pid_t[scam_params->ca_pid.pid]) {
-				got_pid_t[scam_params->ca_pid.pid]=1;
+			if (!(scam_params->got_pid_t[scam_params->ca_pid.pid])) {
+				scam_params->got_pid_t[scam_params->ca_pid.pid]=1;
 				if(scam_params->ca_pid.index != -1) {
 					if (!(chan_and_pids.started_pid_get[scam_params->ca_pid.index])) {
 					  for (curr_channel = 0; curr_channel < chan_and_pids.number_of_channels  && !got_pid; curr_channel++) {

--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -926,6 +926,8 @@ int unicast_reply_write(struct unicast_reply *reply, const char* msg, ...)
 */
 int unicast_reply_send(struct unicast_reply *reply, int socket, int code, const char* content_type)
 {
+  int size=0;
+  int temp_size=0;
   //we add the header information
   reply->type = REPLY_HEADER;
   unicast_reply_write(reply, "HTTP/1.0 ");
@@ -949,11 +951,8 @@ int unicast_reply_send(struct unicast_reply *reply, int socket, int code, const 
   reply->buffer_header = realloc(reply->buffer_header, reply->used_header+reply->used_body);
   memcpy(&reply->buffer_header[reply->used_header],reply->buffer_body,sizeof(char)*reply->used_body);
   reply->used_header+=reply->used_body;
-  //int size=write(socket, reply->buffer_header, reply->used_header);
+	
   //now we write the data
-  int size=0;
-  int temp_size=0;
-
   while (size<reply->used_header){
 	temp_size = write(socket, reply->buffer_header+size, reply->used_header-size);
 	size += temp_size!=-1 ? temp_size : 0 ;


### PR DESCRIPTION
My sincere apologies for the last pull request, I was commiting at work and had broken author of my commits.

Fix for full autoconfiguration is for situation when on multiplex psi tables are some ghost channels that have some of the pids of channels that are vaild. It was making mumudvb crash because we link oscam index from ca_pid and ca_descr with oscam channels based on pids comming in ca_pid messages and mumudvb was getting ca_pid messages with the same pid for different channels.

Fix for unicast http messages amends situation when message is too long to be handled in one write to socket. Bug can be observed when reading state.xml from different unit than this running mumudvb, because on loop-back write length limit I believe is higher than on real nic.
