### PR TITLE
Corrected build for Android. Included 0xc0 service type for Brazilian "1...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,13 @@ then
   fi
 fi
 
+AC_ARG_ENABLE(android,
+  [  --enable-android          Build for android (default disabled)],,[enable_android="no"])
+
+if test "${enable_android}" = "yes"
+then
+  AC_DEFINE(ANDROID, 1, Define if you want build for android)
+fi
 
 # Checks for header files.
 AC_HEADER_RESOLV
@@ -149,6 +156,12 @@ if test "${atsc_long_names}" = "yes" ; then
         echo "Build with ATSC long names support:                 yes"
 else
         echo "Build with ATSC long names support:                  no"
+fi
+
+if test "${enable_android}" = "yes" ; then
+        echo "Build with compatibility for android:               yes"
+else
+        echo "Build with compatibility for android:                no"
 fi
 
 echo ""

--- a/scripts/android_build.sh
+++ b/scripts/android_build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Build script to android. Change the variables on "Path block" to the correct path.
+
+API=8
+
+# Path block
+ANDROID_NDK=/home/ounao/android-ndk-r9c		# Android NDK path
+SRC_DIR=/home/ounao/source/MuMuDVB		# Path to MuMuDVB source
+INSTALL_DIR=/home/ounao/source/out		# Path to android MuMuDVB install
+INCLUDE_DIR=/home/ounao/source/out/include	# Path to linux/dvb headers (obrigatory) and iconv.h (optional)
+LIB_DIR=/home/ounao/source/out/lib		# Path to libiconv.a (optional)
+# Path block
+
+cd $SRC_DIR
+
+export PATH="$ANDROID_NDK/toolchains/arm-linux-androideabi-4.6/prebuilt/linux-x86_64/bin/:$PATH"
+export SYS_ROOT="$ANDROID_NDK/platforms/android-$API/arch-arm/"
+export CC="arm-linux-androideabi-gcc --sysroot=$SYS_ROOT"
+export CXX="arm-linux-androideabi-g++ --sysroot=$SYS_ROOT"
+export CPP="arm-linux-androideabi-cpp --sysroot=$SYS_ROOT"
+export LD="arm-linux-androideabi-ld"
+export AR="arm-linux-androideabi-ar"
+export RANLIB="arm-linux-androideabi-ranlib"
+export STRIP="arm-linux-androideabi-strip"
+export LDFLAGS="-L$LIB_DIR"
+export CFLAGS="-I$INCLUDE_DIR"
+export LIBS="-lc -lgcc -liconv"
+
+./configure --host=arm-eabi --enable-android --prefix=$INSTALL_DIR
+
+make
+make install

--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -658,7 +658,8 @@ int autoconf_services_to_channels(const auto_p_t *parameters, mumudvb_channel_t 
 			if((service->type==0x01||
 					service->type==0x11||
 					service->type==0x16||
-					service->type==0x19)||
+					service->type==0x19||
+					service->type==0xc0)||
 					((service->type==0x02||
 							service->type==0x0a)&&parameters->autoconf_radios))
 			{

--- a/src/log.c
+++ b/src/log.c
@@ -1070,7 +1070,7 @@ int convert_en300468_string(char *string, int max_len)
 	//Conversion to utf8
 	iconv_t cd;
 	//we open the conversion table
-	cd = iconv_open( "UTF8", encodings_en300468[encoding_control_char] );
+	cd = iconv_open( "UTF-8", encodings_en300468[encoding_control_char] );
 
 	size_t inSize, outSize=max_len;
 	inSize=len;

--- a/src/log.c
+++ b/src/log.c
@@ -1070,7 +1070,15 @@ int convert_en300468_string(char *string, int max_len)
 	//Conversion to utf8
 	iconv_t cd;
 	//we open the conversion table
-	cd = iconv_open( "UTF-8", encodings_en300468[encoding_control_char] );
+	cd = iconv_open( "UTF8", encodings_en300468[encoding_control_char] );
+	if (cd == (iconv_t) -1) {
+	  log_message( log_module, MSG_DETAIL, "\t\t UTF8 encoding not supported by iconv. Trying UTF-8.\n");
+	  cd = iconv_open( "UTF-8", encodings_en300468[8]);
+	  if (cd == (iconv_t) -1) {
+	    log_message( log_module, MSG_DETAIL, "\t\t Neither UTF8 or UTF-8 encoding supported by iconv. No name encoding conversion.\n");
+	    goto exit_iconv;
+	  }
+	}
 
 	size_t inSize, outSize=max_len;
 	inSize=len;
@@ -1086,6 +1094,7 @@ int convert_en300468_string(char *string, int max_len)
 	log_message( log_module, MSG_DETAIL, "Iconv not present, no name encoding conversion \n");
 #endif
 
+exit_iconv:
 	log_message( log_module, MSG_FLOOD, "Converted text : \"%s\" (text encoding : %s)\n", string,encodings_en300468[encoding_control_char]);
 	return encoding_control_char;
 

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -131,7 +131,7 @@
 #include "rtp.h"
 #include "log.h"
 
-#ifdef __UCLIBC__
+#if defined __UCLIBC__ || defined ANDROID
 #define program_invocation_short_name "mumudvb"
 #else
 extern char *program_invocation_short_name;
@@ -1469,7 +1469,9 @@ main (int argc, char **argv)
 			free(dump_filename);
 		}
 	}
+#ifndef ANDROID
 	mlockall(MCL_CURRENT | MCL_FUTURE);
+#endif	
 	/******************************************************/
 	//Main loop where we get the packets and send them
 	/******************************************************/
@@ -1865,7 +1867,7 @@ int mumudvb_close(int no_daemon,
 	{
 		log_message(log_module,MSG_DEBUG,"Signal/power Thread closing\n");
 		*strengththreadshutdown=1;
-#ifndef __UCLIBC__
+#if !defined __UCLIBC__ && !defined ANDROID
 		clock_gettime(CLOCK_REALTIME, &ts);
 		ts.tv_sec += 5;
 		iRet=pthread_timedjoin_np(signalpowerthread, NULL, &ts);
@@ -1888,7 +1890,7 @@ int mumudvb_close(int no_daemon,
 	{
 		log_message(log_module,MSG_DEBUG,"Monitor Thread closing\n");
 		monitor_thread_params->threadshutdown=1;
-#ifndef __UCLIBC__
+#if !defined __UCLIBC__ && !defined ANDROID
 		clock_gettime(CLOCK_REALTIME, &ts);
 		ts.tv_sec += 5;
 		iRet=pthread_timedjoin_np(monitorthread, NULL, &ts);
@@ -2028,8 +2030,9 @@ int mumudvb_close(int no_daemon,
 	}
 	if(log_params.log_header!=NULL)
 		free(log_params.log_header);
+#ifndef ANDROID
 	munlockall();
-
+#endif
 	// End
 	return(ExitCode);
 

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -99,7 +99,11 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <signal.h>
+#ifdef ANDROID
+#include <limits.h>
+#else
 #include <values.h>
+#endif
 #include <string.h>
 #include <syslog.h>
 #include <getopt.h>

--- a/src/ts.h
+++ b/src/ts.h
@@ -32,6 +32,8 @@
 
 #include <sys/types.h>
 #include <stdint.h>
+#include <pthread.h>
+#include <endian.h>
 
 #include "config.h"
 

--- a/src/tune.c
+++ b/src/tune.c
@@ -37,7 +37,11 @@
 #include <sys/ioctl.h>
 #include <sys/poll.h>
 #include <unistd.h>
+#ifdef ANDROID
+#include <err.h>
+#else
 #include <error.h>
+#endif
 #include <errno.h>
 #include <string.h>
 

--- a/src/tune.c
+++ b/src/tune.c
@@ -37,6 +37,7 @@
 #include <sys/ioctl.h>
 #include <sys/poll.h>
 #include <unistd.h>
+#include "config.h"
 #ifdef ANDROID
 #include <err.h>
 #else


### PR DESCRIPTION
...seg" mobile TV transmission.

This patch is needed to build and correctly run on android.
Included 0xc0 service type to correctly identify Brazilian "1seg" TV transmission.
