### PR TITLE
fix parsing of port_http in combination with spaces

### DIFF
--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -206,7 +206,7 @@ int read_unicast_configuration(unicast_parameters_t *unicast_vars, mumudvb_chann
 	}
 	else if (!strcmp (substring, "port_http"))
 	{
-		substring = strtok (NULL, delimiteurs);
+		substring = strtok (NULL, "=");
 		if((strchr(substring,'*')!=NULL)||(strchr(substring,'+')!=NULL)||(strchr(substring,'%')!=NULL))
 		{
 			unicast_vars->portOut_str=malloc(sizeof(char)*(strlen(substring)+1));

--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -206,7 +206,7 @@ int read_unicast_configuration(unicast_parameters_t *unicast_vars, mumudvb_chann
 	}
 	else if (!strcmp (substring, "port_http"))
 	{
-		substring = strtok (NULL, "");
+		substring = strtok (NULL, delimiteurs);
 		if((strchr(substring,'*')!=NULL)||(strchr(substring,'+')!=NULL)||(strchr(substring,'%')!=NULL))
 		{
 			unicast_vars->portOut_str=malloc(sizeof(char)*(strlen(substring)+1));

--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -207,6 +207,17 @@ int read_unicast_configuration(unicast_parameters_t *unicast_vars, mumudvb_chann
 	else if (!strcmp (substring, "port_http"))
 	{
 		substring = strtok (NULL, "=");
+
+		// next we replace all the spaces as too many spaces are messing with the further parsing
+		// like: "     port_http            = 2000 + %card"
+		int len = strlen(substring)+1;
+		substring = mumu_string_replace(substring, &len, 1, " ", "");
+
+		// if the string is empty after the replacement, we need to tokenize one more time to get the actual setting
+		if (strlen(substring) == 0) {
+			substring = strtok(NULL, "=");
+		}
+
 		if((strchr(substring,'*')!=NULL)||(strchr(substring,'+')!=NULL)||(strchr(substring,'%')!=NULL))
 		{
 			unicast_vars->portOut_str=malloc(sizeof(char)*(strlen(substring)+1));


### PR DESCRIPTION
- fixes braice/MuMuDVB#102
- previously the setting only properly worked when used without any spaces between the setting and the equals sign (port_http=)
- this is now fixed and an arbitrary number of spaces may be used (like any other setting)
- works by stripping all spaces and if this produces an empty string, do another round of tokenizing to get the actual setting.
- also tested if there are multiple spaces after the equals sign.
- example:
  
  ```
  port_http            = 2000+%card
  ```

(4 spaces in the beginning, 12 spaces before the equal sign and one after)
