### PR TITLE
address is spelled with two 'd's

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -85,7 +85,7 @@ Bugs corrected :
 
 New features : 
  * Option multicast_ttl to override default ttl
- * Option autoconf_ip_header, to change the first part of ip adresses used by autoconfiguration
+ * Option autoconf_ip_header, to change the first part of ip addresses used by autoconfiguration
  * Option sap_default_group
  * Init scripts, cf scripts/ directory
  * Smaller memory footprint

--- a/doc/QUICKSTART.txt
+++ b/doc/QUICKSTART.txt
@@ -54,7 +54,7 @@ mumudvb -d -c __path to config file__
 
 
 - That's all, you should get a list of the streamed channels with their IP
-adresses
+addresses
 
 [NOTE]
 The SAP (session announcement protocol) announces will be sent automatically.

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -250,7 +250,7 @@ srate=27500
 autoconfiguration=full
 ----------------------
 
-The channels will be streamed over the multicasts ip adresses 239.100.c.n where c is the card number (0 by default) and n is the channel number.
+The channels will be streamed over the multicasts ip addresses 239.100.c.n where c is the card number (0 by default) and n is the channel number.
 
 If you don't use the common_port directive, MuMuDVB will use the port 1234.
 
@@ -376,7 +376,7 @@ ip=239.42.42.2
 SAP announces
 -------------
 
-SAP (Session Announcement Protocol) announces are made for the client to know which channels are streamed and what is their name and adress. It avoids to give to the client the list of the multicast ip adresses.
+SAP (Session Announcement Protocol) announces are made for the client to know which channels are streamed and what is their name and address. It avoids to give to the client the list of the multicast ip addresses.
 
 VLC and most of set-top boxes are known to support them.
 
@@ -546,9 +546,9 @@ Get the channels list
 
 If you server is listening on the ip 10.0.1 and the port 4242,
 
-To get the channel list (in basic html) just enter the adress `http://10.0.0.1:4242/channels_list.html` in your web browser.
+To get the channel list (in basic html) just enter the address `http://10.0.0.1:4242/channels_list.html` in your web browser.
 
-To get the channel list (in JSON) just enter the adress `http://10.0.0.1:4242/channels_list.json` in your web browser.
+To get the channel list (in JSON) just enter the address `http://10.0.0.1:4242/channels_list.json` in your web browser.
 
 HTTP unicast and monitoring
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration_examples/autoconf_partial.conf
+++ b/doc/configuration_examples/autoconf_partial.conf
@@ -63,7 +63,7 @@ sap_default_group=My channels
 # * The name
 # * At least the PMT pid (if there is more than one pid, no autoconfiguration will be done for this chanel)
 #
-#Ip adress
+#Ip address
 ip=239.210.203.200
 #Name of the channel
 name=BBC World News

--- a/doc/configuration_examples/example.conf
+++ b/doc/configuration_examples/example.conf
@@ -58,7 +58,7 @@ sap_default_group=My channels
 # * The name
 # * At least the PMT, Video and Audio PIDs
 #
-#Ip adress
+#Ip address
 ip=239.210.203.200
 #Name of the channel
 name=BBC World News


### PR DESCRIPTION
fix spelling error: address is spelled with two 'd's

Signed-off-by: Michael Ira Krufky mkrufky@linuxtv.org
