### PR TITLE
Update for latest Oscam versions (r11200 and later)

### DIFF
--- a/src/scam_getcw.c
+++ b/src/scam_getcw.c
@@ -192,7 +192,7 @@ static void *getcwthread_func(void* arg)
                 pthread_mutex_unlock(&channel->cw_lock);
               } else {
                 pthread_mutex_lock(&channel->cw_lock);
-                if(scam_params->ca_pid.index != -1 && !channel->ca_idx_refcnt) {
+                if(!channel->ca_idx_refcnt) {
                   channel->ca_idx = scam_params->ca_pid.index+1;
                   log_message( log_module,  MSG_INFO, "Got CA_SET_PID with pid: %d setting channel %s ca_idx %d\n", scam_params->ca_pid.pid, channel->name, scam_params->ca_pid.index+1);
                 }

--- a/src/scam_getcw.c
+++ b/src/scam_getcw.c
@@ -47,6 +47,11 @@
 
 #include <dvbcsa/dvbcsa.h>
 
+
+#define DVBAPI_OPCODE_LEN        5
+#define DVBAPI_CA_SET_DESCR_LEN  21
+#define DVBAPI_CA_SET_PID_LEN    13
+
 /**@file
  * @brief scam support
  * 
@@ -132,7 +137,7 @@ static void *getcwthread_func(void* arg)
             channel->ca_idx = 0;
             pthread_mutex_unlock(&channel->cw_lock);
           } else {
-            cRead = recv(channel->camd_socket, &buff, sizeof(buff), 0);
+            cRead = recv(channel->camd_socket, &buff, DVBAPI_OPCODE_LEN, 0);
             if (cRead <= 0) {
               log_message(log_module, MSG_ERROR,"channel: %s recv", channel->name);
               set_interrupted(ERROR_NETWORK<<8);
@@ -141,6 +146,20 @@ static void *getcwthread_func(void* arg)
               return 0;
             }
             request = (int *) (buff + 1);
+            if (*request == CA_SET_DESCR)
+            {
+                //read upt to DVBAPI_CA_SET_DESCR_LEN
+                cRead = recv(channel->camd_socket, (buff + DVBAPI_OPCODE_LEN), (DVBAPI_CA_SET_DESCR_LEN - DVBAPI_OPCODE_LEN), 0);
+                if (cRead != (DVBAPI_CA_SET_DESCR_LEN - DVBAPI_OPCODE_LEN))
+                    *request = 0;
+            }
+            else if (*request == CA_SET_PID)
+            {
+                //read upt to DVBAPI_CA_SET_PID_LEN
+                cRead = recv(channel->camd_socket, (buff + DVBAPI_OPCODE_LEN), (DVBAPI_CA_SET_PID_LEN - DVBAPI_OPCODE_LEN), 0);
+                if (cRead != (DVBAPI_CA_SET_PID_LEN - DVBAPI_OPCODE_LEN))
+                    *request = 0;
+            }
             if (*request == CA_SET_DESCR) {
               memcpy((&(scam_params->ca_descr)), buff + 1 + sizeof(int), sizeof(ca_descr_t));
               log_message( log_module,  MSG_DEBUG, "Got CA_SET_DESCR request for channel: %s, index: %d, parity %d, key %02x %02x %02x %02x %02x %02x %02x %02x\n", channel->name, scam_params->ca_descr.index, scam_params->ca_descr.parity, scam_params->ca_descr.cw[0], scam_params->ca_descr.cw[1], scam_params->ca_descr.cw[2], scam_params->ca_descr.cw[3], scam_params->ca_descr.cw[4], scam_params->ca_descr.cw[5], scam_params->ca_descr.cw[6], scam_params->ca_descr.cw[7]);
@@ -165,15 +184,15 @@ static void *getcwthread_func(void* arg)
               log_message( log_module,  MSG_DEBUG, "Got CA_SET_PID request channel: %s, index: %d pid: %d\n", channel->name, scam_params->ca_pid.index, scam_params->ca_pid.pid);
               if(scam_params->ca_pid.index == -1) {
                 pthread_mutex_lock(&channel->cw_lock);
-                --channel->ca_idx_refcnt;
+                if (channel->ca_idx_refcnt) --channel->ca_idx_refcnt;
                 if (!channel->ca_idx_refcnt) {
                   channel->ca_idx = 0;
-                  log_message( log_module,  MSG_INFO, "Got CA_SET_PID removal request: %d setting channel %s with ca_idx to 0 %d\n", scam_params->ca_pid.pid, channel->name, scam_params->ca_pid.index+1);
+                  log_message( log_module,  MSG_INFO, "Got CA_SET_PID removal request: %d setting channel %s with ca_idx %d to 0\n", scam_params->ca_pid.pid, channel->name, scam_params->ca_pid.index+1);
                 }
                 pthread_mutex_unlock(&channel->cw_lock);
               } else {
                 pthread_mutex_lock(&channel->cw_lock);
-                if(!channel->ca_idx_refcnt) {
+                if(scam_params->ca_pid.index != -1 && !channel->ca_idx_refcnt) {
                   channel->ca_idx = scam_params->ca_pid.index+1;
                   log_message( log_module,  MSG_INFO, "Got CA_SET_PID with pid: %d setting channel %s ca_idx %d\n", scam_params->ca_pid.pid, channel->name, scam_params->ca_pid.index+1);
                 }


### PR DESCRIPTION
Fixes:
1 - oscam sends a CA_SET_PID with -1 for the needed CA PID after the PMT sending.
This will get the channel>ca_idx__refcnt to -1, which will prevent any further CA_SET_PID acceptance for this channel
2 - the camd socket will tend to overrun on reception, so instead of getting the needed 13 bytes packet of a CA_SET_PID, it will also get the beginning of the next one, thus desynchronizing the PID settings. This does not happen always, but most of the time.
