### PR TITLE
add sid ignore list for autoconfig

### DIFF
--- a/doc/README_CONF.txt
+++ b/doc/README_CONF.txt
@@ -297,6 +297,7 @@ HTTP unicast parameters
 |unicast_consecutive_errors_timeout | The timeout for disconnecting a client which is not responding | 5 | A client will be disconnected if no data have been sucessfully sent during this interval. A value of 0 deactivate the timeout (unadvised).
 |unicast_max_clients | The limit on the number of connected clients | 0 | 0 : no limit.
 |unicast_queue_size | The maximum size of the buffering when writting to a client fails | 512kBytes | in Bytes.
+|playlist_ignore_dead | Do we include dead channels (no traffic) in playlist? | 0  | 0 or 1 |
 |==================================================================================================================
 
 

--- a/doc/README_CONF.txt
+++ b/doc/README_CONF.txt
@@ -297,7 +297,7 @@ HTTP unicast parameters
 |unicast_consecutive_errors_timeout | The timeout for disconnecting a client which is not responding | 5 | A client will be disconnected if no data have been sucessfully sent during this interval. A value of 0 deactivate the timeout (unadvised).
 |unicast_max_clients | The limit on the number of connected clients | 0 | 0 : no limit.
 |unicast_queue_size | The maximum size of the buffering when writting to a client fails | 512kBytes | in Bytes.
-|playlist_ignore_dead | Do we include dead channels (no traffic) in playlist? | 0  | 0 or 1 |
+|playlist_ignore_dead | Do we exclude dead channels (no traffic) from playlist? | 0  | 0 or 1 | Exclude dead and include alive channels on each playlist request.
 |==================================================================================================================
 
 

--- a/doc/README_CONF.txt
+++ b/doc/README_CONF.txt
@@ -267,6 +267,7 @@ Autoconfiguration parameters
 |autoconf_unicast_port |The unicast port for each discovered channel. Ex "2000+%number" |  |  | You can use expressions with `+` `*` `%card` `%tuner` `%server`, `%sid` and `%number`. Ex : `autoconf_unicast_port=2000+100*%card+%number`
 |autoconf_multicast_port |The multicast port for each discovered channel. Ex "2000+%number" |  |  | You can use expressions with `+` `*` `%card` `%tuner` `%server`, `%sid` and `%number`. Ex : `autoconf_multicast_port=2000+100*%card+%number`
 |autoconf_sid_list | If you don't want to configure all the channels of the transponder in autoconfiguration mode, specify with this option the list of the service ids of the channels you want to autoconfigure. | empty |  | 
+|autoconf_sid_list_ignore | If you don't want to configure all the channels of the transponder in autoconfiguration mode, specify with this option the list of the service ids of the channels you want to exclude from autoconfiguration. | empty |  | 
 |autoconf_name_template | The template for the channel name, ex `%number-%name` | empty | | See README for more details
 |==================================================================================================================
 

--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -230,6 +230,21 @@ int read_autoconfiguration_configuration(auto_p_t *auto_p, char *substring)
 			auto_p->num_service_id++;
 		}
 	}
+	else if (!strcmp (substring, "autoconf_sid_list_ignore"))
+	{
+		while ((substring = strtok (NULL, delimiteurs)) != NULL)
+		{
+			if (auto_p->num_service_id_ignore >= MAX_CHANNELS)
+			{
+				log_message( log_module,  MSG_ERROR,
+						"Autoconfiguration : Too many ignored ts id : %d\n",
+						auto_p->num_service_id_ignore);
+				return -1;
+			}
+			auto_p->service_id_list_ignore[auto_p->num_service_id_ignore] = atoi (substring);
+			auto_p->num_service_id_ignore++;
+		}
+	}
 	else if (!strcmp (substring, "autoconf_name_template"))
 	{
 		// other substring extraction method in order to keep spaces
@@ -364,11 +379,12 @@ void autoconf_update_chan_status(auto_p_t *auto_p,mumu_chan_p_t *chan_p)
 				chan_p->channels[ichan].channel_ready=NO_STREAMING;
 				continue;
 		}
+		int found_in_service_id_list;
 		//The service was autodetected, we check it's present in the SID list
 		if(auto_p->num_service_id)
 		{
 			int sid_i;
-			int found_in_service_id_list=0;
+			found_in_service_id_list=0;
 			for(sid_i=0;sid_i<auto_p->num_service_id && !found_in_service_id_list;sid_i++)
 			{
 				if(auto_p->service_id_list[sid_i]==chan_p->channels[ichan].service_id)
@@ -386,8 +402,29 @@ void autoconf_update_chan_status(auto_p_t *auto_p,mumu_chan_p_t *chan_p)
 				chan_p->channels[ichan].channel_ready=NO_STREAMING;
 				continue;
 			}
-		}
 
+		}
+		//The service was autodetected, we check it's present in the ignore list
+		if(auto_p->num_service_id_ignore)
+		{
+			int sid_i;
+			found_in_service_id_list=1;
+			for(sid_i=0;sid_i<auto_p->num_service_id_ignore;sid_i++)
+			{
+				if(auto_p->service_id_list_ignore[sid_i]==chan_p->channels[ichan].service_id)
+				{
+					found_in_service_id_list=0;
+				}
+			}
+			if(found_in_service_id_list==0)
+			{
+				log_message( log_module, MSG_DETAIL,"Service in ignore list, we skip. Name \"%s\", id %d\n",
+						chan_p->channels[ichan].name,
+						chan_p->channels[ichan].service_id);
+				chan_p->channels[ichan].channel_ready=NO_STREAMING;
+				continue;
+			}
+		}
 
 		//Cf EN 300 468 v1.9.1 Table 81
 		//Everything seems to be OK, we check if this is a radio or a TV channel

--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -379,12 +379,11 @@ void autoconf_update_chan_status(auto_p_t *auto_p,mumu_chan_p_t *chan_p)
 				chan_p->channels[ichan].channel_ready=NO_STREAMING;
 				continue;
 		}
-		int found_in_service_id_list;
 		//The service was autodetected, we check it's present in the SID list
 		if(auto_p->num_service_id)
 		{
 			int sid_i;
-			found_in_service_id_list=0;
+			int found_in_service_id_list=0;
 			for(sid_i=0;sid_i<auto_p->num_service_id && !found_in_service_id_list;sid_i++)
 			{
 				if(auto_p->service_id_list[sid_i]==chan_p->channels[ichan].service_id)
@@ -408,15 +407,15 @@ void autoconf_update_chan_status(auto_p_t *auto_p,mumu_chan_p_t *chan_p)
 		if(auto_p->num_service_id_ignore)
 		{
 			int sid_i;
-			found_in_service_id_list=1;
+			int found_in_service_id_ignore_list=0;
 			for(sid_i=0;sid_i<auto_p->num_service_id_ignore;sid_i++)
 			{
 				if(auto_p->service_id_list_ignore[sid_i]==chan_p->channels[ichan].service_id)
 				{
-					found_in_service_id_list=0;
+					found_in_service_id_ignore_list=1;
 				}
 			}
-			if(found_in_service_id_list==0)
+			if(found_in_service_id_ignore_list==1)
 			{
 				log_message( log_module, MSG_DETAIL,"Service in ignore list, we skip. Name \"%s\", id %d\n",
 						chan_p->channels[ichan].name,

--- a/src/autoconf.h
+++ b/src/autoconf.h
@@ -120,6 +120,12 @@ Possible values for this variable
 	int service_id_list[MAX_CHANNELS];
 	/**number of SID*/
 	int num_service_id;
+
+	/**the list of ignored SID for full autoconfiguration*/
+	int service_id_list_ignore[MAX_CHANNELS];
+	/**number of SID*/
+	int num_service_id_ignore;
+
 	/** the template for the channel name*/
 	char name_template[MAX_NAME_LEN];
 

--- a/src/log.c
+++ b/src/log.c
@@ -1100,7 +1100,7 @@ int convert_en300468_string(char *string, int max_len, int debug)
 
     tempdest=tempbuf=malloc(sizeof(char)*lenstring+1);
 
-    log_message( log_module, MSG_DEBUG,"String len %d offset %ld",lenstring, realstart-((unsigned char *)string));
+    log_message( log_module, MSG_DEBUG,"String len %d offset %zd",lenstring, realstart-((unsigned char *)string));
 	if(tempdest==NULL)
 	{
 		log_message( log_module, MSG_ERROR,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
@@ -1165,7 +1165,7 @@ int convert_en300468_string(char *string, int max_len, int debug)
 	*dest = '\0';
 	free(tempbuf);
 	iconv_close( cd );
-	log_message( log_module, MSG_FLOOD, "Converted text : \"%s\" (text encoding : %s)\nnonreversible conversions %ld", string,encodings_en300468[encoding_control_char],nonreversible);
+	log_message( log_module, MSG_FLOOD, "Converted text : \"%s\" (text encoding : %s)\nnonreversible conversions %zd", string,encodings_en300468[encoding_control_char],nonreversible);
 #else
 	if(debug) {log_message( log_module, MSG_DETAIL, "Iconv not present, no name encoding conversion \n");}
 #endif

--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -83,9 +83,9 @@ unicast_send_streamed_channels_list (int number_of_channels, mumudvb_channel_t *
 int
 unicast_send_index_page  (int Socket);
 int
-unicast_send_play_list_unicast (int number_of_channels, mumudvb_channel_t *channels, int Socket, int unicast_portOut, int perport);
+unicast_send_play_list_unicast (int number_of_channels, mumudvb_channel_t *channels, int Socket, int unicast_portOut, int perport, unicast_parameters_t *unicast_vars);
 int
-unicast_send_play_list_multicast (int number_of_channels, mumudvb_channel_t* channels, int Socket, int vlc);
+unicast_send_play_list_multicast (int number_of_channels, mumudvb_channel_t* channels, int Socket, int vlc, unicast_parameters_t *unicast_vars);
 int
 unicast_send_streamed_channels_list_js (int number_of_channels, mumudvb_channel_t *channels, void* cam_p_v, int Socket);
 int
@@ -134,6 +134,7 @@ void init_unicast_v(unicast_parameters_t *unicast_vars)
 				.socket_sendbuf_size=0,
 				.flush_on_eagain=0,
 				.pfdsnum=0,
+				.playlist_ignore_dead=0,
 	 };
 	 unicast_vars->pfds=NULL;
 	 //+1 for closing the pfd list, see man poll
@@ -249,6 +250,11 @@ int read_unicast_configuration(unicast_parameters_t *unicast_vars, mumudvb_chann
 		unicast_vars->flush_on_eagain = atoi (substring);
 		if(unicast_vars->flush_on_eagain)
 			log_message( log_module,  MSG_INFO, "The unicast data WILL be dropped on eagain errors\n");
+	}
+	else if (!strcmp (substring, "playlist_ignore_dead"))
+	{
+		substring = strtok (NULL, delimiteurs);
+		unicast_vars->playlist_ignore_dead = atoi (substring);
 	}
 	else
 		return 0; //Nothing concerning tuning, we return 0 to explore the other possibilities
@@ -769,26 +775,26 @@ int unicast_handle_message(unicast_parameters_t *unicast_vars,
 			else if(strstr(client->buffer +pos ,"/playlist.m3u ")==(client->buffer +pos))
 			{
 				log_message( log_module, MSG_DETAIL,"play list\n");
-				unicast_send_play_list_unicast (number_of_channels, channels, client->Socket, unicast_vars->portOut, 0 );
+				unicast_send_play_list_unicast (number_of_channels, channels, client->Socket, unicast_vars->portOut, 0, unicast_vars );
 				return -2; //We close the connection afterwards
 			}
 			//playlist, m3u
 			else if(strstr(client->buffer +pos ,"/playlist_port.m3u ")==(client->buffer +pos))
 			{
 				log_message( log_module, MSG_DETAIL,"play list\n");
-				unicast_send_play_list_unicast (number_of_channels, channels, client->Socket, unicast_vars->portOut, 1 );
+				unicast_send_play_list_unicast (number_of_channels, channels, client->Socket, unicast_vars->portOut, 1, unicast_vars );
 				return -2; //We close the connection afterwards
 			}
 			else if(strstr(client->buffer +pos ,"/playlist_multicast.m3u ")==(client->buffer +pos))
 			{
 				log_message( log_module, MSG_DETAIL,"play list\n");
-				unicast_send_play_list_multicast (number_of_channels, channels, client->Socket, 0);
+				unicast_send_play_list_multicast (number_of_channels, channels, client->Socket, 0, unicast_vars );
 				return -2; //We close the connection afterwards
 			}
 			else if(strstr(client->buffer +pos ,"/playlist_multicast_vlc.m3u ")==(client->buffer +pos))
 			{
 				log_message( log_module, MSG_DETAIL,"play list\n");
-				unicast_send_play_list_multicast (number_of_channels, channels, client->Socket, 1);
+				unicast_send_play_list_multicast (number_of_channels, channels, client->Socket, 1, unicast_vars );
 				return -2; //We close the connection afterwards
 			}
 			//statistics, text version
@@ -1124,7 +1130,7 @@ unicast_send_streamed_channels_list (int number_of_channels, mumudvb_channel_t *
  * @param perport says if the channel have to be given by the url /bysid or by their port
  */
 int
-unicast_send_play_list_unicast (int number_of_channels, mumudvb_channel_t *channels, int Socket, int unicast_portOut, int perport)
+unicast_send_play_list_unicast (int number_of_channels, mumudvb_channel_t *channels, int Socket, int unicast_portOut, int perport, unicast_parameters_t *unicast_vars)
 {
 	int curr_channel,iRet;
 
@@ -1151,7 +1157,7 @@ unicast_send_play_list_unicast (int number_of_channels, mumudvb_channel_t *chann
 
 	//"#EXTINF:0,title\r\nURL"
 	for (curr_channel = 0; curr_channel < number_of_channels; curr_channel++)
-		if (channels[curr_channel].channel_ready>=READY)
+		if (channels[curr_channel].channel_ready>=READY && (channels[curr_channel].has_traffic == 1 || unicast_vars->playlist_ignore_dead == 0))
 		{
 			if(!perport)
 			{
@@ -1243,7 +1249,7 @@ unicast_send_index_page (int Socket)
  * @param Socket the socket on wich the information have to be sent
  */
 int
-unicast_send_play_list_multicast (int number_of_channels, mumudvb_channel_t *channels, int Socket, int vlc)
+unicast_send_play_list_multicast (int number_of_channels, mumudvb_channel_t *channels, int Socket, int vlc, unicast_parameters_t *unicast_vars)
 {
 	int curr_channel;
 	char urlheader[4];
@@ -1266,7 +1272,7 @@ unicast_send_play_list_multicast (int number_of_channels, mumudvb_channel_t *cha
 
 	//"#EXTINF:0,title\r\nURL"
 	for (curr_channel = 0; curr_channel < number_of_channels; curr_channel++)
-		if (channels[curr_channel].channel_ready>=READY)
+		if (channels[curr_channel].channel_ready>=READY && (channels[curr_channel].has_traffic == 1 || unicast_vars->playlist_ignore_dead == 0))
 		{
 			if(channels[curr_channel].rtp)
 				strcpy(urlheader,"rtp");

--- a/src/unicast_http.h
+++ b/src/unicast_http.h
@@ -196,6 +196,7 @@ typedef struct unicast_parameters_t{
   /**File descriptors for pooling*/
   struct pollfd *pfds;	//unicast http clients
   int pfdsnum;
+  int playlist_ignore_dead;
 
 }unicast_parameters_t;
 


### PR DESCRIPTION
This feature is used to exclude some channels found at autoconfiguration, so you can avoid some sid without touching others.

like that:
autoconf_sid_list_ignore=1810 1990
