### PR TITLE
add support for PMT rewrite

### DIFF
--- a/doc/README.txt
+++ b/doc/README.txt
@@ -61,7 +61,7 @@ Features overview
 - Support for automatic configuration i.e channels discovery and follow changes, see <<autoconfiguration,Autoconfiguration>> section
 - Generation of SAP announces, see <<sap,SAP>> section
 - Support of DVB-S2, DVB-S, DVB-C, DVB-T and ATSC
-- Possibility to partially rewrite the stream for better compatibility with set-top boxes and some clients. See <<pat_rewrite,PAT Rewrite>> and <<sdt_rewrite,SDT Rewrite>> sections.
+- Possibility to partially rewrite the stream for better compatibility with set-top boxes and some clients. See <<pat_rewrite,PAT Rewrite>>, <<sdt_rewrite,SDT Rewrite>> and <<pmt_rewrite,PMT rewrite>> sections.
 - Support for HTTP unicast see <<unicast,http unicast>> section
 - Support for RTP headers (only for multicast)
 - CAM menu access while streaming (using a web/AJAX interface - see WEBSERVICES.txt and CAM_menu_interface.png for screenshot)
@@ -825,6 +825,19 @@ To enable SDT rewriting, add `rewrite_sdt=1` to your config file. This feature c
 
 [NOTE]
 If you don't use full autoconfiguration, SDT rewrite needs the `service_id` option for each channel to specify the service id.
+
+[[pmt_rewrite]]
+PMT (Program Map Table) Rewriting
+-----------------------------------------
+
+This option must be used if you don't stream all PIDs for a channel. It's useful for separating one channel with multiple audio streams (multiple languages) into separate channels.
+
+Without PMT rewrite, players can get confused due to missing streams, especially if the first PID in the table is not streamed, and the playback may fail. However, teletext PID can usually be dropped safely without rewriting PMT, as it's the last PID in the table.
+
+To enable PMT rewriting, add `rewrite_pmt=1` to your config file.
+
+[NOTE]
+PMT rewrite will work only if PIDs are set manually. If they are autodetected, everything will be streamed so there's no need to rewrite the PMT.
 
 
 

--- a/doc/README_CONF.txt
+++ b/doc/README_CONF.txt
@@ -197,6 +197,7 @@ Packets sending parameters
 |psi_tables_filtering | If set to 'pat', TS packets with PID from 0x01 to 0x1F are discarded. If set to 'pat_cat', TS packets with PID from 0x02 to 0x1F are discarded. | 'none' | Option to keep only mandatory PSI PID | 
 |rewrite_pat | Do we rewrite the PAT PID | 0, 1 in autoconf | 0 or 1 | See README, important for some set top boxes 
 |rewrite_sdt | Do we rewrite the SDT PID | 0, 1 in autoconf | 0 or 1 | See README 
+|rewrite_pmt | Do we rewrite the PMT PID | 0 | 0 or 1 | See README, important if you don't stream all PIDs
 |rewrite_eit sort_eit | Do we rewrite/sort the EIT PID | 0 | 0 or 1 | See README 
 |sdt_force_eit | Do we force the EIT_schedule_flag and EIT_present_following_flag in SDT | 0 | 0 or 1 | Set to 0 if you don't understand
 |rtp_header | Send the stream with the rtp headers (except for HTTP unicast) | 0 | 0 or 1 | 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ mumudvb_test_SOURCES = mumudvb_test.c autoconf.c crc32.c dvb.h log.c log.h multi
 bin_PROGRAMS = mumudvb
 mumudvb_SOURCES = autoconf.c crc32.c dvb.h log.c log.h multicast.c mumudvb.h network.h rewrite.h \
 		  rtp.h sap.h ts.h tune.h unicast_http.h autoconf.h dvb.c errors.h \
-		  mumudvb.c mumudvb_mon.c mumudvb_mon.h mumudvb_common.c network.c rewrite_pat.c rewrite.c rewrite_sdt.c rewrite_eit.c \
+		  mumudvb.c mumudvb_mon.c mumudvb_mon.h mumudvb_common.c network.c rewrite_pmt.c rewrite_pat.c rewrite.c rewrite_sdt.c rewrite_eit.c \
 		  rtp.c sap.c ts.c tune.c unicast_http.c unicast_queue.c unicast_EIT.c autoconf_sdt.c autoconf_atsc.c \
 		  autoconf_pmt.c autoconf_nit.c unicast_clients.c unicast_monit.c mumudvb_channels.c \
 		  autoconf_pat.c

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -558,6 +558,8 @@ main (int argc, char **argv)
 			}
 			//Pids are now user set, they won't be overwritten by autoconfiguration
 			c_chan->pid_i.pid_f=F_USER;
+			//Enable PMT rewrite
+			c_chan->pmt_rewrite = 1;
 			while ((substring = strtok (NULL, delimiteurs)) != NULL)
 			{
 				c_chan->pid_i.pids[ipid] = atoi (substring);
@@ -597,18 +599,6 @@ main (int argc, char **argv)
 				return -1;
 			}
 			MU_F(c_chan->pid_i.pmt_pid)=F_USER;
-		}
-		else if (!strcmp (substring, "skip_pmt_rewrite"))
-		{
-			if ( c_chan == NULL)
-			{
-				log_message( log_module,  MSG_ERROR,
-					"skip_pmt_rewrite : You have to start a channel first (using new_channel)\n");
-				return -1;
-			}
-			log_message(log_module, MSG_INFO, "PMT rewrite skipped on channel %d", ichan);
-			substring = strtok (NULL, delimiteurs);
-			c_chan->skip_pmt_rewrite = atoi (substring);
 		}
 		else if (!strcmp (substring, "name"))
 		{
@@ -1489,7 +1479,7 @@ main (int argc, char **argv)
 						(pid == chan_p.channels[ichan].pid_i.pmt_pid) && //This is a PMT PID
 						(chan_p.channels[ichan].pid_i.pmt_pid) && //we have the pmt_pid
 						(rewrite_vars.rewrite_pmt == OPTION_ON ) && //AND we asked for rewrite
-						(chan_p.channels[ichan].skip_pmt_rewrite != 1))  //AND we didn't specify skipping
+						(chan_p.channels[ichan].pmt_rewrite == 1))  //AND this channel's PMT shouldn't be skipped
 				{
 					send_packet=pmt_rewrite_new_channel_packet(actual_ts_packet, pmt_ts_packet, &chan_p.channels[ichan], ichan);
 				}
@@ -1542,7 +1532,7 @@ main (int argc, char **argv)
 				if(send_packet==1)
 				{
 					/**Special PMT case*/
-					if(pid == chan_p.channels[ichan].pid_i.pmt_pid)
+					if((pid == chan_p.channels[ichan].pid_i.pmt_pid) && (rewrite_vars.rewrite_pmt == OPTION_ON ) && (chan_p.channels[ichan].pmt_rewrite == 1))
 						buffer_func(channel, pmt_ts_packet, &unic_p, scam_vars_ptr);
 					else
 						buffer_func(channel, actual_ts_packet, &unic_p, scam_vars_ptr);

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -461,6 +461,11 @@ typedef struct mumu_chan_t{
 	unsigned char generated_pmt[TS_PACKET_SIZE];
 	/** Do we rewrite PMT for this channel? */
 	int pmt_rewrite;
+	/** PMT can span over multiple TS packets */
+	int pmt_part_num;
+	int pmt_part_count;
+	unsigned char original_pmt[TS_PACKET_SIZE*10];
+	int original_pmt_ready;
 	/** The version of the generated pmt */
 	int generated_pmt_version;
 	/** The continuity counter for pmt packets */

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -459,8 +459,8 @@ typedef struct mumu_chan_t{
 
 	/**The generated PMT to be sent*/
 	unsigned char generated_pmt[TS_PACKET_SIZE];
-	/** Do we skip PMT rewrite for this channel? */
-	int skip_pmt_rewrite;
+	/** Do we rewrite PMT for this channel? */
+	int pmt_rewrite;
 	/** The version of the generated pmt */
 	int generated_pmt_version;
 	/** The continuity counter for pmt packets */

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -457,6 +457,14 @@ typedef struct mumu_chan_t{
 	//do we need to update the SAP announce (typically a name change)
 	int sap_need_update;
 
+	/**The generated PMT to be sent*/
+	unsigned char generated_pmt[TS_PACKET_SIZE];
+	/** Do we skip PMT rewrite for this channel? */
+	int skip_pmt_rewrite;
+	/** The version of the generated pmt */
+	int generated_pmt_version;
+	/** The continuity counter for pmt packets */
+	int pmt_continuity_counter;
 	/**The generated pat to be sent*/
 	unsigned char generated_pat[TS_PACKET_SIZE];
 	/** The version of the generated pat */

--- a/src/rewrite.c
+++ b/src/rewrite.c
@@ -45,6 +45,7 @@ static char *log_module="Rewrite: ";
 void init_rewr_v(rewrite_parameters_t *rewr_p)
 {
 	*rewr_p=(rewrite_parameters_t){
+				.rewrite_pmt = OPTION_UNDEFINED,
 				.rewrite_pat = OPTION_UNDEFINED,
 				.pat_version=-1,
 				.full_pat=NULL,
@@ -138,7 +139,19 @@ return 0;
 int read_rewrite_configuration(rewrite_parameters_t *rewrite_vars, char *substring)
 {
 	char delimiteurs[] = CONFIG_FILE_SEPARATOR;
-	if (!strcmp (substring, "rewrite_pat"))
+	if (!strcmp (substring, "rewrite_pmt"))
+	{
+		substring = strtok (NULL, delimiteurs);
+		if(atoi (substring))
+		{
+			rewrite_vars->rewrite_pmt = OPTION_ON;
+			log_message( log_module, MSG_INFO,
+					"You have enabled the PMT Rewriting\n");
+		}
+		else
+			rewrite_vars->rewrite_pmt = OPTION_OFF;
+	}
+	else if (!strcmp (substring, "rewrite_pat"))
 	{
 		substring = strtok (NULL, delimiteurs);
 		if(atoi (substring))

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -77,6 +77,9 @@ typedef struct eit_packet_t{
  * This structure contain the parameters needed for rewriting
  */
 typedef struct rewrite_parameters_t{
+	/**Do we rewrite the PMT pid ?*/
+	option_status_t rewrite_pmt;
+
 	/**Do we rewrite the PAT pid ?*/
 	option_status_t rewrite_pat;
 	/**The actual version of the PAT pid*/
@@ -130,6 +133,8 @@ typedef struct rewrite_parameters_t{
 void init_rewr_v(rewrite_parameters_t *rewr_p);
 int rewrite_init(rewrite_parameters_t *rewr_p);
 int read_rewrite_configuration(rewrite_parameters_t *rewrite_vars, char *substring);
+
+int pmt_rewrite_new_channel_packet(unsigned char *ts_packet, unsigned char *pmt_ts_packet, mumudvb_channel_t *channel, int curr_channel);
 
 void pat_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars);
 int pat_rewrite_new_channel_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars, mumudvb_channel_t *channel, int curr_channel);

--- a/src/rewrite_pmt.c
+++ b/src/rewrite_pmt.c
@@ -1,0 +1,187 @@
+/*
+ * MuMuDVB - Stream a DVB transport stream.
+ * PMT rewrite by Danijel Tudek, Dec 2016.
+ *
+ * (C) 2008-2013 Brice DUBOST <mumudvb@braice.net>
+ *
+ * Parts of this code come from libdvb, modified for mumudvb
+ * by Brice DUBOST
+ * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
+ *
+ * The latest version can be found at http://mumudvb.braice.net
+ *
+ * Copyright notice:
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/** @file
+ *  @brief This file contains code for PMT rewrite
+ *  PMT must be rewritten if we don't stream all PIDs, otherwise some players
+ *  may get confused.
+ *  (See "Problem with streaming individual PIDs", Nov 2016 on mailing list.)
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "mumudvb.h"
+#include "ts.h"
+#include "rewrite.h"
+#include "log.h"
+#include <stdint.h>
+
+extern uint32_t crc32_table[256];
+static char *log_module = "PMT rewrite: ";
+
+/**
+ * @brief Check the streamed PMT version and compare to the stored PMT.
+ * @param ts_packet
+ * @param channel
+ * @return return 1 if update is needed
+ */
+int pmt_need_update(unsigned char *ts_packet, mumudvb_channel_t *channel) {
+	pmt_t *pmt = (pmt_t *) (ts_packet + TS_HEADER_LEN);
+	if (pmt->version_number != channel->generated_pmt_version) {
+		log_message(log_module, MSG_DEBUG, "PMT changed, old version: %d, new version: %d, rewriting...",
+					channel->generated_pmt_version, pmt->version_number);
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+/** @brief Main function for PMT rewrite.
+ * The goal of this function is to make a new PMT with only the announcement for the streamed PIDs for each channel.
+ * By default it contains all PIDs which confuses players if we don't actually stream all of them.
+ * The PMT is read and the list of PIDs is compared to user-specified PID list for the channel.
+ * If there is a match, PID is copied to generated PMT.
+ * @param ts_packet
+ * @param channel
+ * @return 0
+ */
+int pmt_channel_rewrite(unsigned char *ts_packet, mumudvb_channel_t *channel) {
+	ts_header_t *ts_header = (ts_header_t *) ts_packet;
+	pmt_t *pmt = (pmt_t *) (ts_packet + TS_HEADER_LEN);
+
+	if (pmt->table_id != 0x02) {
+		log_message(log_module, MSG_DETAIL, "We didn't get the good PMT (wrong table ID 0x%02X), search for a new one",
+					pmt->table_id);
+		return 0;
+	}
+
+	pmt_info_t *pmt_info;
+	unsigned long crc32;
+	//destination buffer
+	unsigned char buf_dest[TS_PACKET_SIZE];
+	int buf_dest_pos = 0;
+
+	int section_length = 0, elem_pid = 0;
+	int new_section_length = 0;
+	int es_info_len = 0;
+	int new_es_info_len = 0;
+
+	int i = 0, j = 0;
+
+	log_message(log_module, MSG_DEBUG, "PMT pid = %d; channel name = \"%s\"\n", channel->pmt_packet->pid,
+				channel->name);
+
+	section_length = HILO(pmt->section_length) + 3;
+
+	//lets start the copy
+	//we copy the ts header and adapt it a bit
+	//the continuity counter is updated elsewhere
+	if (ts_header->payload_unit_start_indicator) {
+		if (ts_packet[TS_HEADER_LEN - 1])
+			log_message(log_module, MSG_DEBUG, "pointer field 0x%x \n", ts_packet[TS_HEADER_LEN - 1]);
+	}
+	ts_header->payload_unit_start_indicator = 1;
+	ts_packet[TS_HEADER_LEN - 1] = 0; //we erase the pointer field
+	//we copy the modified SDT header
+	pmt->current_next_indicator = 1; //applicable immediately
+	pmt->section_number = 0;
+	pmt->last_section_number = 0;
+
+	memcpy(buf_dest, ts_header, TS_HEADER_LEN + PMT_LEN);
+	buf_dest_pos = TS_HEADER_LEN + PMT_LEN;
+
+	/**
+	 * Parse PMT
+	 */
+	int es_len = section_length - PMT_LEN - 4;
+	log_message(log_module, MSG_DEBUG, "Number of PIDs requested from PMT: %d\n", channel->pid_i.num_pids-1); // one of them is PMT PID itself
+	for (i = 0; i < es_len; i += PMT_INFO_LEN + es_info_len) {
+		pmt_info = (pmt_info_t *) ((char *) pmt + PMT_LEN + i);
+		elem_pid = HILO(pmt_info->elementary_PID);
+		es_info_len = HILO(pmt_info->ES_info_length);
+		for (j = 0; j < channel->pid_i.num_pids; j++) {
+			if (elem_pid == channel->pid_i.pids[j]) {
+				new_es_info_len += PMT_INFO_LEN + es_info_len;
+				log_message(log_module, MSG_DEBUG, " PID %d found, copy to new PMT\n", channel->pid_i.pids[j]);
+				memcpy(buf_dest + buf_dest_pos, pmt_info, PMT_INFO_LEN + es_info_len);
+				buf_dest_pos += PMT_INFO_LEN + es_info_len;
+			}
+		}
+	}
+
+	new_section_length = buf_dest_pos - TS_HEADER_LEN + 1;
+
+	//We write the new section length
+	buf_dest[1 + TS_HEADER_LEN] = (((new_section_length) & 0x0f00) >> 8) | (0xf0 & buf_dest[1 + TS_HEADER_LEN]);
+	buf_dest[2 + TS_HEADER_LEN] = new_section_length & 0xff;
+
+	//CRC32 calculation inspired by the xine project
+	//Now we must adjust the CRC32
+	//we compute the CRC32
+	crc32 = 0xffffffff;
+	for (i = 0; i < new_section_length - 1; i++) {
+		crc32 = (crc32 << 8) ^ crc32_table[((crc32 >> 24) ^ buf_dest[i + TS_HEADER_LEN]) & 0xff];
+	}
+
+	//We write the CRC32 to the buffer
+	buf_dest[buf_dest_pos] = (crc32 >> 24) & 0xff;
+	buf_dest_pos += 1;
+	buf_dest[buf_dest_pos] = (crc32 >> 16) & 0xff;
+	buf_dest_pos += 1;
+	buf_dest[buf_dest_pos] = (crc32 >> 8) & 0xff;
+	buf_dest_pos += 1;
+	buf_dest[buf_dest_pos] = crc32 & 0xff;
+	buf_dest_pos += 1;
+
+	//Padding with 0xFF
+	memset(buf_dest + buf_dest_pos, 0xFF, TS_PACKET_SIZE - buf_dest_pos);
+
+	//update generated PMT version (matches the original PMT version)
+	channel->generated_pmt_version = pmt->version_number;
+	memcpy(channel->generated_pmt, buf_dest, TS_PACKET_SIZE);
+
+	//Everything is OK
+	return 1;
+}
+
+int pmt_rewrite_new_channel_packet(unsigned char *ts_packet, unsigned char *pmt_ts_packet, mumudvb_channel_t *channel, int curr_channel) {
+	if (channel->channel_ready >= READY && pmt_need_update(ts_packet, channel))
+		if (!pmt_channel_rewrite(ts_packet, channel)) {
+			log_message(log_module, MSG_DEBUG, "Cannot rewrite (for the moment) the PMT for the channel %d : \"%s\"\n",
+						curr_channel, channel->name);
+			return 0;
+		}
+	channel->pmt_continuity_counter++;
+	channel->pmt_continuity_counter = channel->pmt_continuity_counter % 32;
+	memcpy(pmt_ts_packet, channel->generated_pmt, TS_PACKET_SIZE);
+	set_continuity_counter(pmt_ts_packet, channel->pmt_continuity_counter);
+	return 1;
+}

--- a/src/rewrite_pmt.c
+++ b/src/rewrite_pmt.c
@@ -175,6 +175,7 @@ int pmt_channel_rewrite(unsigned char *ts_packet, mumudvb_channel_t *channel) {
 	memset(buf_dest + buf_dest_pos, 0xFF, TS_PACKET_SIZE - buf_dest_pos);
 
 	//update generated PMT version (matches the original PMT version)
+	log_message(log_module, MSG_DEBUG, "PMT rewritten\n");
 	channel->generated_pmt_version = pmt->version_number;
 	memcpy(channel->generated_pmt, buf_dest, TS_PACKET_SIZE);
 

--- a/src/rewrite_pmt.c
+++ b/src/rewrite_pmt.c
@@ -158,20 +158,15 @@ int pmt_channel_rewrite(mumudvb_channel_t *channel) {
 		pmt_info = (pmt_info_t *) ((char *) pmt + PMT_LEN + i);
 		elem_pid = HILO(pmt_info->elementary_PID);
 		es_info_len = HILO(pmt_info->ES_info_length);
-		//Prevent read overflow
-		if (i + PMT_LEN + 4 + PMT_INFO_LEN + es_info_len >= 184) {
-			log_message(log_module, MSG_ERROR, " Read overflow detected, aborting parsing");
+		//Prevent write overflow
+		if(buf_dest_pos + PMT_INFO_LEN + es_info_len >= TS_PACKET_SIZE - 4) {
+			log_message(log_module, MSG_DEBUG, "  Write overflow detected, aborting copy");
 			break;
 		}
 		for (j = 0; j < channel->pid_i.num_pids; j++) {
 			if (elem_pid == channel->pid_i.pids[j]) {
 				new_es_info_len += PMT_INFO_LEN + es_info_len;
 				log_message(log_module, MSG_DEBUG, " PID %d found, copy to new PMT\n", channel->pid_i.pids[j]);
-				//Prevent write overflow
-				if(buf_dest_pos + PMT_INFO_LEN + es_info_len >= 184) {
-					log_message(log_module, MSG_DEBUG, "  Write overflow detected, aborting copy");
-					break;
-				}
 				memcpy(buf_dest + buf_dest_pos, pmt_info, PMT_INFO_LEN + es_info_len);
 				buf_dest_pos += PMT_INFO_LEN + es_info_len;
 			}


### PR DESCRIPTION
Hi,
This is the PMT rewrite function we discussed on mailing list.
I tested it on EuroNews channel where I discovered the problem and I don't see any issues.

Features:
- PMT rewrite must be explicitly enabled (rewrite_pmt=1)
- once enabled, it will be active for all channels
- it can be disabled individually with skip_pmt_rewrite=1
- not tested on scrambled channels with CAM/SCAM

Since this allows us to separate single channel's audio streams into different channels, PMT PID can't be modified directly.  
I had to create new pmt_ts_packet[TS_PACKET_SIZE] array which is sent to buffer_func instead of actual_ts_packet. Otherwise, the PMT would get rewritten for the first channel and passed in that modified state for the rest of the channels with the same PMT PID, which would result in PMT without audio PID.