### PR TITLE
Fix memory leaks

### DIFF
--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -8,7 +8,7 @@
  * by Brice DUBOST
  * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -326,6 +326,11 @@ int autoconf_init(auto_p_t *auto_p)
  */
 void autoconf_freeing(auto_p_t *auto_p)
 {
+	if(auto_p->autoconf_temp_nit)
+	{
+		free(auto_p->autoconf_temp_nit);
+		auto_p->autoconf_temp_nit=NULL;
+	}
 	if(auto_p->autoconf_temp_sdt)
 	{
 		free(auto_p->autoconf_temp_sdt);

--- a/src/autoconf_atsc.c
+++ b/src/autoconf_atsc.c
@@ -8,7 +8,7 @@
  * by Brice DUBOST 
  * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/autoconf_nit.c
+++ b/src/autoconf_nit.c
@@ -8,7 +8,7 @@
  * by Brice DUBOST 
  * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/autoconf_pat.c
+++ b/src/autoconf_pat.c
@@ -8,7 +8,7 @@
  * by Brice DUBOST
  * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/autoconf_pmt.c
+++ b/src/autoconf_pmt.c
@@ -8,7 +8,7 @@
  * by Brice DUBOST 
  * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/autoconf_sdt.c
+++ b/src/autoconf_sdt.c
@@ -170,6 +170,8 @@ int autoconf_read_sdt(auto_p_t *auto_p, mumu_chan_p_t *chan_p)
 				case 4:  log_message( log_module, MSG_FLOOD, "\trunning_status : running\n");  break; //too usual to be printed as debug
 				case 5:
 					log_message( log_module, MSG_DEBUG, "\trunning_status : service off-air\n");  break;
+				default:
+					log_message( log_module, MSG_DEBUG, "\trunning_status : unknown (0x%x)\n", descr_header->running_status);  break;
 				}
 				//we store the Free CA mode flag (tell if the channel is scrambled)
 				chan_p->channels[chan].free_ca_mode=descr_header->free_ca_mode;

--- a/src/autoconf_sdt.c
+++ b/src/autoconf_sdt.c
@@ -8,7 +8,7 @@
  * by Brice DUBOST 
  * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/cam.c
+++ b/src/cam.c
@@ -387,6 +387,8 @@ int cam_start(cam_p_t *cam_p, int adapter_id,mumu_chan_p_t *chan_p)
 	case DVBCA_INTERFACE_HLCI:
 		log_message( log_module,  MSG_DETAIL,  "CAM type : HIGH level interface\n");
 		break;
+	default:
+		log_message( log_module,  MSG_DETAIL,  "CAM type : UNKNOWN (0x%x)\n", cam_p->cam_type);
 	}
 
 	// start the cam thread
@@ -585,7 +587,8 @@ static void *camthread_func(void* arg)
 					log_message( log_module,  MSG_DEBUG,  "cam state : DVBCA_CAMSTATE_INITIALISING\n");
 					break;
 				case -1:
-					log_message( log_module,  MSG_DEBUG,  "cam state : Eroor during the query\n");
+				default:
+					log_message( log_module,  MSG_DEBUG,  "cam state : Error during the query (0x%x)\n", camstate);
 					break;
 				}
 				usleep(10000);

--- a/src/cam.c
+++ b/src/cam.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2011 Brice DUBOST <mumudvb@braice.net>
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Code inspired by libdvben50221 examples from dvb apps
  * Copyright (C) 2004, 2005 Manu Abraham <abraham.manu@gmail.com>

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -3,7 +3,7 @@
  * 
  * (C) 2004-2009 Brice DUBOST
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -469,6 +469,9 @@ void show_card_capabilities( int card, int tuner )
 	case FE_ATSC:
 		log_message( log_module,  MSG_INFO, " ATSC card\n");
 		break;
+	default:
+		log_message( log_module,  MSG_INFO, " UNKNOWN card (0x%x)\n", fe_info.type);
+		break;
 	}
 	if(fe_info.type==FE_QPSK)
 		frequency_factor=1000;

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -4,7 +4,7 @@
  * (C) 2004-2013 Brice DUBOST
  * (C) Dave Chapman <dave@dchapman.com> 2001, 2002.
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/log.c
+++ b/src/log.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2013 Brice DUBOST
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 
@@ -956,7 +956,7 @@ void print_info ()
 			"---------\n"
 			"Originally based on dvbstream 0.6 by (C) Dave Chapman 2001-2004\n"
 			"Released under the GPL.\n"
-			"Latest version available from http://mumudvb.braice.net/\n"
+			"Latest version available from http://mumudvb.net/\n"
 			"Project from the cr@ns (http://www.crans.org)\n"
 			"by Brice DUBOST (mumudvb@braice.net)\n\n"
 #if DVB_API_VERSION >= 5

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -5,7 +5,7 @@
  * (C) 2009 Brice DUBOST
  *
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -174,7 +174,7 @@ void init_multicast_v(multi_p_t *multi_p); //in multicast.c
 
 void chan_new_pmt(unsigned char *ts_packet, mumu_chan_p_t *chan_p, int pid);
 
-int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* output_buf, int output_buf_offset, unsigned int output_buf_size, uint8_t plpId);
+int processt2(unsigned char* input_buf, unsigned int input_buf_offset, unsigned char* output_buf, unsigned int output_buf_offset, unsigned int output_buf_size, uint8_t plpId);
 
 int
 main (int argc, char **argv)

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -1705,8 +1705,8 @@ main (int argc, char **argv)
 					&signalpowerthread,
 					&monitorthread,
 					&cardthreadparams,
-					&fds);
-
+					&fds,
+					&card_buffer);
 }
 
 

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -9,7 +9,7 @@
  * Copyright (C) 2006 Andrew de Quincey (adq_dvb@lidskialf.net)
  * 
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -174,7 +174,7 @@ void init_multicast_v(multi_p_t *multi_p); //in multicast.c
 
 void chan_new_pmt(unsigned char *ts_packet, mumu_chan_p_t *chan_p, int pid);
 
-int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* output_buf, int output_buf_offset, uint8_t plpId);
+int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* output_buf, int output_buf_offset, unsigned int output_buf_size, uint8_t plpId);
 
 int
 main (int argc, char **argv)
@@ -270,6 +270,7 @@ main (int argc, char **argv)
 	memset (&card_buffer, 0, sizeof (card_buffer_t));
 	card_buffer.dvr_buffer_size=DEFAULT_TS_BUFFER_SIZE;
 	card_buffer.max_thread_buffer_size=DEFAULT_THREAD_BUFFER_SIZE;
+	unsigned int t2mi_buf_size = 0;
 	/** List of mandatory pids */
 	uint8_t mandatory_pid[MAX_MANDATORY_PID_NUMBER];
 
@@ -1231,10 +1232,11 @@ main (int argc, char **argv)
 		cardthreadparams.main_waiting=0;
 		if (chan_p.t2mi_pid > 0) {
 		    if (card_buffer.write_buffer_size < TS_PACKET_SIZE*349) {
-			card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*349); /* we must hold at least one t2mi frame! */
+			t2mi_buf_size = sizeof(unsigned char)*TS_PACKET_SIZE*349; /* we must hold at least one t2mi frame! */
 		    } else {
-			card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*card_buffer.write_buffer_size*2);
+			t2mi_buf_size = sizeof(unsigned char)*card_buffer.write_buffer_size*2;
 		    }
+		    card_buffer.t2mi_buffer=malloc(t2mi_buf_size);
 		}
 		
 	}else
@@ -1243,10 +1245,11 @@ main (int argc, char **argv)
 		card_buffer.reading_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*card_buffer.dvr_buffer_size);
 		if (chan_p.t2mi_pid > 0) {
 		    if (card_buffer.dvr_buffer_size < 349) {
-		        card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*349); /* we must hold at least one t2mi frame! */
+			t2mi_buf_size = sizeof(unsigned char)*TS_PACKET_SIZE*349; /* we must hold at least one t2mi frame! */
 		    } else {
-		        card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*card_buffer.dvr_buffer_size*2);
+			t2mi_buf_size = sizeof(unsigned char)*TS_PACKET_SIZE*card_buffer.dvr_buffer_size*2;
 		    }
+		    card_buffer.t2mi_buffer=malloc(t2mi_buf_size);
 		}
 	}
 
@@ -1387,7 +1390,7 @@ main (int argc, char **argv)
                     	    if(chan_p.t2mi_pid != (((card_buffer.reading_buffer[card_buffer.read_buff_pos+1] & 0x1f) << 8) | (card_buffer.reading_buffer[card_buffer.read_buff_pos+2]))) {
                                 continue;
                     	    }
-                    	    processed += processt2(card_buffer.reading_buffer, card_buffer.read_buff_pos, card_buffer.t2mi_buffer, t2_partial_size + processed, chan_p.t2mi_plp);
+                    	    processed += processt2(card_buffer.reading_buffer, card_buffer.read_buff_pos, card_buffer.t2mi_buffer, t2_partial_size + processed, t2mi_buf_size, chan_p.t2mi_plp);
     			}
 
 			/* in case we got too much errors */

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -1230,8 +1230,8 @@ main (int argc, char **argv)
 		card_buffer.writing_buffer=card_buffer.buffer2;
 		cardthreadparams.main_waiting=0;
 		if (chan_p.t2mi_pid > 0) {
-		    if (card_buffer.write_buffer_size < 65536) {
-			card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*65536); /* we must hold at least one t2mi frame! */
+		    if (card_buffer.write_buffer_size < TS_PACKET_SIZE*349) {
+			card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*349); /* we must hold at least one t2mi frame! */
 		    } else {
 			card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*card_buffer.write_buffer_size*2);
 		    }
@@ -1242,8 +1242,8 @@ main (int argc, char **argv)
 		//We alloc the buffer
 		card_buffer.reading_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*card_buffer.dvr_buffer_size);
 		if (chan_p.t2mi_pid > 0) {
-		    if (card_buffer.dvr_buffer_size < 348) {
-		        card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*348); /* we must hold at least one t2mi frame! */
+		    if (card_buffer.dvr_buffer_size < 349) {
+		        card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*349); /* we must hold at least one t2mi frame! */
 		    } else {
 		        card_buffer.t2mi_buffer=malloc(sizeof(unsigned char)*TS_PACKET_SIZE*card_buffer.dvr_buffer_size*2);
 		    }

--- a/src/mumudvb_channels.c
+++ b/src/mumudvb_channels.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2014 Brice DUBOST
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/mumudvb_common.c
+++ b/src/mumudvb_common.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2014 Brice DUBOST
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -331,7 +331,28 @@ int mumudvb_close(int no_daemon,
 		free(rewrite_vars->full_sdt);
 
 	//EIT rewrite freeing
-	if(rewrite_vars->full_eit)
+	if (rewrite_vars->eit_packets)
+	{
+		struct eit_packet_t *eit_packet, *eit_next_packet;
+		eit_packet = rewrite_vars->eit_packets;
+		/* recursive free of eit packet storage */
+		while (eit_packet) {
+
+		    for(int i=0;i<MAX_EIT_SECTIONS;i++)
+            		if(eit_packet->full_eit_sections[i]!=NULL)
+                    	    free(eit_packet->full_eit_sections[i]);
+
+		    if (eit_packet->next) {
+			eit_next_packet = eit_packet->next;
+			free (eit_packet);
+			eit_packet = eit_next_packet;
+		    } else {
+			free (eit_packet);
+			break;
+		    }
+		}
+	}
+	if (rewrite_vars->full_eit)
 		free(rewrite_vars->full_eit);
 
 	if (strlen(filename_channels_streamed) && (write_streamed_channels)&&remove (filename_channels_streamed))

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -187,7 +187,8 @@ int mumudvb_close(int no_daemon,
 		pthread_t *signalpowerthread,
 		pthread_t *monitorthread,
 		card_thread_parameters_t *cardthreadparams,
-		fds_t *fds)
+		fds_t *fds,
+		card_buffer_t *card_buffer)
 {
 
 	int curr_channel;
@@ -354,6 +355,17 @@ int mumudvb_close(int no_daemon,
 		}
 	}
 
+	/*free packet buffers*/
+	if (card_buffer->threaded_read) {
+    	    if (card_buffer->buffer1) free(card_buffer->buffer1);
+    	    if (card_buffer->buffer2) free(card_buffer->buffer2);
+    	} else {
+    	    if (card_buffer->reading_buffer) free(card_buffer->reading_buffer);
+    	}
+
+        if (chan_p->t2mi_pid > 0) {
+    	    if (card_buffer->t2mi_buffer) free(card_buffer->t2mi_buffer);
+        }
 
 	/*free the file descriptors*/
 	if(fds->pfds)

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -301,8 +301,8 @@ int mumudvb_close(int no_daemon,
 					cam_p->filename_cam_info, strerror (errno));
 		}
 		mumu_free_string(&cam_p->cam_menulist_str);
-		mumu_free_string(&cam_p->cam_menu_string);
 	}
+	mumu_free_string(&cam_p->cam_menu_string); /* string is allocated in init_cam_v() even with cam support disabled */
 #endif
 #ifdef ENABLE_SCAM_SUPPORT
 	if(scam_vars->scam_support)
@@ -372,12 +372,18 @@ int mumudvb_close(int no_daemon,
         }
 
 	/*free the file descriptors*/
-	if(fds->pfds)
+	if(fds->pfds) {
 		free(fds->pfds);
-	fds->pfds=NULL;
-	if(unicast_vars->fd_info)
+		fds->pfds=NULL;
+	}
+	if(unicast_vars->fd_info) {
 		free(unicast_vars->fd_info);
-	unicast_vars->fd_info=NULL;
+		unicast_vars->fd_info=NULL;
+	}
+	if(unicast_vars->pfds) {
+		free(unicast_vars->pfds);
+		unicast_vars->pfds=NULL;
+	}
 
 	// Format ExitCode (normal exit)
 	int ExitCode;

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -328,6 +328,10 @@ int mumudvb_close(int no_daemon,
 	if(rewrite_vars->full_sdt)
 		free(rewrite_vars->full_sdt);
 
+	//EIT rewrite freeing
+	if(rewrite_vars->full_eit)
+		free(rewrite_vars->full_eit);
+
 	if (strlen(filename_channels_streamed) && (write_streamed_channels)&&remove (filename_channels_streamed))
 	{
 		log_message( log_module,  MSG_WARN,

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -157,6 +157,8 @@ void parse_cmd_line(int argc, char **argv,char *(*conf_filename),tune_p_t *tune_
 			strncpy (*dump_filename, optarg, strlen (optarg) + 1);
 			log_message( log_module, MSG_WARN,"You've decided to dump the received stream into %s. Be warned, it can grow quite fast", *dump_filename);
 			break;
+		default: /* -Wswitch-default */
+			break;
 		}
 	}
 	if (optind < argc)

--- a/src/mumudvb_mon.h
+++ b/src/mumudvb_mon.h
@@ -40,7 +40,8 @@ int mumudvb_close(int no_daemon,
 		pthread_t *signalpowerthread,
 		pthread_t *monitorthread,
 		card_thread_parameters_t *cardthreadparams,
-		fds_t *fds);
+		fds_t *fds,
+		card_buffer_t *card_buffer);
 
 
 void parse_cmd_line(int argc, char **argv,

--- a/src/mumudvb_test.c
+++ b/src/mumudvb_test.c
@@ -4,7 +4,7 @@
  *
  * (C) 2010 Brice DUBOST <mumudvb@braice.net>
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *
@@ -25,7 +25,7 @@
 
 
 /* The test files can be found here :
-http://mumudvb.braice.net/mumudvb/test/
+http://mumudvb.net/mumudvb/test/
 */
 
 // To compile this code, run "make check"

--- a/src/network.c
+++ b/src/network.c
@@ -5,7 +5,7 @@
  * (C) 2004-2013 Brice DUBOST
  * (C) Dave Chapman <dave@dchapman.com> 2001, 2002.
  * 
- *  The latest version can be found at http://mumudvb.braice.net
+ *  The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/rewrite.c
+++ b/src/rewrite.c
@@ -3,7 +3,7 @@
  * 
  * (C) 2004-2010 Brice DUBOST
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -43,6 +43,7 @@
 #include "unicast_http.h"
 #include <stdint.h>
 
+#define MAX_EIT_SECTIONS 256
 
 /** @brief the structure for storing an EIT PID for a particular SID
  * This structure contains the packet and several flags around
@@ -65,7 +66,7 @@ typedef struct eit_packet_t{
 	/**Do the full EIT is ok ?*/
 	int full_eit_ok;
 	/** The Complete EIT PID  for each section*/
-	mumudvb_ts_packet_t* full_eit_sections[256];
+	mumudvb_ts_packet_t* full_eit_sections[MAX_EIT_SECTIONS];
 	/** The continuity counter of the sent EIT*/
 	int continuity_counter;
 	/** Pointer to the next one */

--- a/src/rewrite_eit.c
+++ b/src/rewrite_eit.c
@@ -3,7 +3,7 @@
  *
  * (C) 2004-2013 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/rewrite_eit.c
+++ b/src/rewrite_eit.c
@@ -105,7 +105,7 @@ uint8_t eit_next_table_id(uint8_t table_id)
 void eit_free_packet_contents(eit_packet_t *eit_packet)
 {
 	//free the different packets
-	for(int i=0;i<256;i++)
+	for(int i=0;i<MAX_EIT_SECTIONS;i++)
 		if(eit_packet->full_eit_sections[i]!=NULL)
 			free(eit_packet->full_eit_sections[i]);
 

--- a/src/rewrite_pat.c
+++ b/src/rewrite_pat.c
@@ -3,7 +3,7 @@
  *
  * (C) 2004-2013 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/rewrite_pmt.c
+++ b/src/rewrite_pmt.c
@@ -8,7 +8,7 @@
  * by Brice DUBOST
  * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/rewrite_pmt.c
+++ b/src/rewrite_pmt.c
@@ -67,8 +67,8 @@ int pmt_need_update(unsigned char *ts_packet, mumudvb_channel_t *channel) {
 			}
 		}
 		if (!channel->original_pmt_ready) {
-			float pmt_length = HILO(pmt->section_length) + 3;
-			channel->pmt_part_num = (int) ceil(pmt_length/TS_PACKET_SIZE) - 1;
+			int pmt_length = HILO(pmt->section_length) + 3;
+			channel->pmt_part_num =	((pmt_length + TS_PACKET_SIZE) % TS_PACKET_SIZE) ? (pmt_length / TS_PACKET_SIZE) : ((pmt_length / TS_PACKET_SIZE) - 1); /* exact ceil() simulation */
 			channel->pmt_part_count = 0;
 			memcpy(channel->original_pmt + (TS_PACKET_SIZE*channel->pmt_part_count), ts_packet, TS_PACKET_SIZE);
 			if (channel->pmt_part_num == 0) {

--- a/src/rewrite_sdt.c
+++ b/src/rewrite_sdt.c
@@ -3,7 +3,7 @@
  *
  * (C) 2004-2013 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -3,7 +3,7 @@
  *
  * (C) 2009 Brice DUBOST <mumudvb@braice.net>
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/sap.c
+++ b/src/sap.c
@@ -3,7 +3,7 @@
  *
  * (C) 2008-2010 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/scam_capmt.c
+++ b/src/scam_capmt.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2010 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Code inspired by vdr plugin dvbapi
  * Copyright (C) 2011,2012 Mariusz Białończyk <manio@skyboo.net>

--- a/src/scam_common.c
+++ b/src/scam_common.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2010 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Code inspired by vdr plugin dvbapi
  * Copyright (C) 2011,2012 Mariusz Białończyk <manio@skyboo.net>

--- a/src/scam_decsa.c
+++ b/src/scam_decsa.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2010 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Code inspired by TSDECRYPT
  * Copyright (C) 2011,2012 Georgi Chorbadzhiyski <georgi@unixsol.org>

--- a/src/scam_getcw.c
+++ b/src/scam_getcw.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2010 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Code inspired by vdr plugin dvbapi
  * Copyright (C) 2011,2012 Mariusz Białończyk <manio@skyboo.net>

--- a/src/scam_send.c
+++ b/src/scam_send.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2010 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/t2mi.c
+++ b/src/t2mi.c
@@ -42,7 +42,7 @@ bool t2mi_first=true;
 int t2_partial_size=0;
 
 int t2packetpos=0;
-char t2packet[65536 + 10]; //Maximal T2 payload + header
+char t2packet[TS_PACKET_SIZE*349]; /* will fit Maximal T2 payload + header */
 
 /* rewritten by [anp/hsw], original code taken from https://github.com/newspaperman/t2-mi */
 int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* output_buf, int output_buf_offset, uint8_t plpId) {

--- a/src/t2mi.c
+++ b/src/t2mi.c
@@ -4,7 +4,7 @@
  * 
  * (C) 2004-2013 Brice DUBOST
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 

--- a/src/t2mi.c
+++ b/src/t2mi.c
@@ -68,10 +68,9 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
             case 0x00:	/* 00b = reserved! */
             	log_message(log_module, MSG_DEBUG, "T2-MI: wrong AF (00) in input stream, accepting as ordinary packet\n");
             break;
-
-            default:	/* -Wswitch-default */
-        	return 0;
-    	    break;
+            
+            default: /* -Wswitch-default */
+            break;
 	}
 
 	/* source buffer pointer to beginning of payload in packet */

--- a/src/t2mi.c
+++ b/src/t2mi.c
@@ -68,6 +68,10 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
             case 0x00:	/* 00b = reserved! */
             	log_message(log_module, MSG_DEBUG, "T2-MI: wrong AF (00) in input stream, accepting as ordinary packet\n");
             break;
+
+            default:	/* -Wswitch-default */
+        	return 0;
+    	    break;
 	}
 
 	/* source buffer pointer to beginning of payload in packet */

--- a/src/t2mi.c
+++ b/src/t2mi.c
@@ -45,7 +45,7 @@ int t2packetpos=0;
 char t2packet[TS_PACKET_SIZE*349]; /* will fit Maximal T2 payload + header */
 
 /* rewritten by [anp/hsw], original code taken from https://github.com/newspaperman/t2-mi */
-int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* output_buf, int output_buf_offset, uint8_t plpId) {
+int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* output_buf, int output_buf_offset, unsigned int output_buf_size, uint8_t plpId) {
 
 	unsigned int payload_start_offset=0;
 	output_buf+=output_buf_offset;
@@ -77,7 +77,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
         unsigned char* buf = input_buf + input_buf_offset + 4 + payload_start_offset;
         unsigned int len = TS_PACKET_SIZE - 4 - payload_start_offset;
 
-        int output_bytes=0;
+        unsigned int output_bytes=0;
 
 	/* check for payload unit start indicator */
         if((((input_buf[input_buf_offset + 1])&0x40)>>4)==0x04) {
@@ -110,24 +110,31 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                         	}
                                 if(syncd==0x1FFF ) { /* maximal sync value (in bytes) */
             				log_message(log_module, MSG_DEBUG, "sync value 0x1FFF!\n");
-                                        if(upl >19) {
-                                                memcpy(output_buf + output_bytes, &t2packet[19], upl-19);
-                                                output_bytes+=(upl-19);
+					unsigned int maxsync = upl - 19;
+                                        if (output_bytes + maxsync > output_buf_size) {
+	                            		log_message(log_module, MSG_DEBUG, "position (max sync) out of buffer bounds: %d + %d > %d\n",
+	                            								    output_bytes, maxsync, output_buf_size);
+	                                	goto t2_copy_end;
+                                        }
+                                        else if (upl > 19) {
+                                                memcpy(output_buf + output_bytes, &t2packet[19], maxsync);
+                                                output_bytes+=maxsync;
                                         }
 
                                 } else {
-                                        if(!t2mi_first && syncd > 0) {
-                                            if (syncd-dnp > (sizeof(t2packet)-19)) {
-	                                	    log_message(log_module, MSG_DEBUG, "position (syncd) out of buffer bounds: %d\n", syncd-dnp);
+                                        if (!t2mi_first && syncd > 0) {
+                                    	    unsigned int syncd_size = syncd - dnp;
+                                            if (syncd_size > (sizeof(t2packet)-19) || output_bytes + syncd_size > output_buf_size) {
+	                                	    log_message(log_module, MSG_DEBUG, "position (syncd) out of buffer bounds: %d + %d > %d\n",
+	                                							    output_bytes, syncd_size, output_buf_size);
 	                                	    goto t2_copy_end;
                                             }
-                                            memcpy(output_buf + output_bytes, &t2packet[19], syncd-dnp);
-                                            output_bytes+=(syncd-dnp);
+                                            memcpy(output_buf + output_bytes, &t2packet[19], syncd_size);
+                                            output_bytes+=syncd_size;
                                         }
 
 					/* detect unaligned packet in buffer */
                                         unsigned int output_part = (output_buf_offset + output_bytes) % TS_PACKET_SIZE;
-                                        
                                         if (output_part > 0) {
                                     	    log_message(log_module, MSG_DETAIL, "unaligned packet in buffer pos %d/%d\n", output_buf_offset, output_bytes);
                                     	    output_bytes -= output_part; /* drop packet; TODO: check if we can add padding instead of dropping */
@@ -139,8 +146,9 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                                         /* copy T2-MI packet payload to output, add sync bytes */
                                         for(; t2_copy_pos < upl - 187; t2_copy_pos+=(187+dnp)) {
                                     		/* fullsize TS frame */
-                                                if (t2_copy_pos > ((sizeof(t2packet) - 187))) {
-                                        	    log_message(log_module, MSG_DEBUG, "position (full TS) out of buffer bounds: %d\n", t2_copy_pos);
+                                                if (t2_copy_pos > ((sizeof(t2packet) - 187)) || output_bytes + TS_PACKET_SIZE > output_buf_size) {
+                                        	    log_message(log_module, MSG_DEBUG, "position (full TS) out of buffer bounds: in %d, out %d + %d > %d\n",
+                                        							    t2_copy_pos, output_bytes, TS_PACKET_SIZE, output_buf_size);
                                         	    goto t2_copy_end;
                                                 }
                                                 output_buf[output_bytes] = TS_SYNC_BYTE;
@@ -150,17 +158,19 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                                         }
                                         if(t2_copy_pos < upl )  {
                                     		/* partial TS frame, we will fill rest of frame at next call */
-                                                if (t2_copy_pos > (sizeof(t2packet)-((upl-t2_copy_pos)+1))) {
-                                        	    log_message(log_module, MSG_DEBUG, "position (part TS) out of buffer bounds: %d\n", t2_copy_pos);
+                                    		unsigned int part_size = upl - t2_copy_pos;
+                                                if (t2_copy_pos > (sizeof(t2packet)-(part_size+1)) || output_bytes + part_size + 1 > output_buf_size) {
+                                        	    log_message(log_module, MSG_DEBUG, "position (part TS) out of buffer bounds: in %d, out %d + %d > %d\n",
+                                        							    t2_copy_pos, output_bytes, part_size + 1, output_buf_size);
                                         	    goto t2_copy_end;
                                                 }
                                                 output_buf[output_bytes] = TS_SYNC_BYTE;
                                                 output_bytes++;
-                                                memcpy(output_buf + output_bytes, &t2packet[t2_copy_pos], upl-t2_copy_pos);
-                                                output_bytes+=(upl-t2_copy_pos);
+                                                memcpy(output_buf + output_bytes, &t2packet[t2_copy_pos], part_size);
+                                                output_bytes+=part_size;
                                         }
-                                        t2_copy_end: ;
                                 }
+                                t2_copy_end: ;
                         }
                         t2mi_active=false;
                         memset(&t2packet, 0, sizeof(t2packet)); // end of processing t2-mi packet, clear it

--- a/src/t2mi.c
+++ b/src/t2mi.c
@@ -56,7 +56,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
 		/* number of bytes in AF, following this byte */
                 payload_start_offset=(uint8_t)(input_buf[input_buf_offset + 4]) + 1;
                 if(payload_start_offset > 183) {
-            		log_message(log_module, MSG_DEBUG, "T2-MI: wrong AF len in input stream: %d\n", payload_start_offset);
+            		log_message(log_module, MSG_DEBUG, "wrong AF len in input stream: %d\n", payload_start_offset);
                         return 0;
                 }
             break;
@@ -66,7 +66,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
             break;
 
             case 0x00:	/* 00b = reserved! */
-            	log_message(log_module, MSG_DEBUG, "T2-MI: wrong AF (00) in input stream, accepting as ordinary packet\n");
+            	log_message(log_module, MSG_DEBUG, "wrong AF (00) in input stream, accepting as ordinary packet\n");
             break;
             
             default: /* -Wswitch-default */
@@ -87,7 +87,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                         if( 1 < offset && offset < 184) {
                                 memcpy(&t2packet[t2packetpos],&buf[1],offset-1);
                         } else if (offset >= 184) {
-            			log_message(log_module, MSG_DEBUG, "T2-MI: invalid payload offset: %u\n", offset);
+            			log_message(log_module, MSG_DEBUG, "invalid payload offset: %u\n", offset);
             			return 0;
                         }
                         
@@ -109,7 +109,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                         	    dnp=1; // Deleted Null Packet
                         	}
                                 if(syncd==0x1FFF ) { /* maximal sync value (in bytes) */
-            				log_message(log_module, MSG_DEBUG, "T2-MI: sync value 0x1FFF!\n");
+            				log_message(log_module, MSG_DEBUG, "sync value 0x1FFF!\n");
                                         if(upl >19) {
                                                 memcpy(output_buf + output_bytes, &t2packet[19], upl-19);
                                                 output_bytes+=(upl-19);
@@ -118,7 +118,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                                 } else {
                                         if(!t2mi_first && syncd > 0) {
                                             if (syncd-dnp > (sizeof(t2packet)-19)) {
-	                                	    log_message(log_module, MSG_DEBUG, "T2-MI: position (syncd) out of buffer bounds: %d\n", syncd-dnp);
+	                                	    log_message(log_module, MSG_DEBUG, "position (syncd) out of buffer bounds: %d\n", syncd-dnp);
 	                                	    goto t2_copy_end;
                                             }
                                             memcpy(output_buf + output_bytes, &t2packet[19], syncd-dnp);
@@ -129,7 +129,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                                         unsigned int output_part = (output_buf_offset + output_bytes) % TS_PACKET_SIZE;
                                         
                                         if (output_part > 0) {
-                                    	    log_message(log_module, MSG_DETAIL, "T2-MI: unaligned packet in buffer pos %d/%d\n", output_buf_offset, output_bytes);
+                                    	    log_message(log_module, MSG_DETAIL, "unaligned packet in buffer pos %d/%d\n", output_buf_offset, output_bytes);
                                     	    output_bytes -= output_part; /* drop packet; TODO: check if we can add padding instead of dropping */
                                         }
 
@@ -140,7 +140,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                                         for(; t2_copy_pos < upl - 187; t2_copy_pos+=(187+dnp)) {
                                     		/* fullsize TS frame */
                                                 if (t2_copy_pos > ((sizeof(t2packet) - 187))) {
-                                        	    log_message(log_module, MSG_DEBUG, "T2-MI: position (full TS) out of buffer bounds: %d\n", t2_copy_pos);
+                                        	    log_message(log_module, MSG_DEBUG, "position (full TS) out of buffer bounds: %d\n", t2_copy_pos);
                                         	    goto t2_copy_end;
                                                 }
                                                 output_buf[output_bytes] = TS_SYNC_BYTE;
@@ -151,7 +151,7 @@ int processt2(unsigned char* input_buf, int input_buf_offset, unsigned char* out
                                         if(t2_copy_pos < upl )  {
                                     		/* partial TS frame, we will fill rest of frame at next call */
                                                 if (t2_copy_pos > (sizeof(t2packet)-((upl-t2_copy_pos)+1))) {
-                                        	    log_message(log_module, MSG_DEBUG, "T2-MI: position (part TS) out of buffer bounds: %d\n", t2_copy_pos);
+                                        	    log_message(log_module, MSG_DEBUG, "position (part TS) out of buffer bounds: %d\n", t2_copy_pos);
                                         	    goto t2_copy_end;
                                                 }
                                                 output_buf[output_bytes] = TS_SYNC_BYTE;

--- a/src/ts.c
+++ b/src/ts.c
@@ -3,7 +3,7 @@
  *
  * (C) 2004-2011 Brice DUBOST <mumudvb@braice.net>
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/tune.c
+++ b/src/tune.c
@@ -1512,6 +1512,7 @@ default:
 		{
 			log_message( log_module,  MSG_ERROR, "Unsupported delivery system. Try tuning using DVB API 3 (do not set delivery_system). And please contact so it can be implemented.\n");
 			set_interrupted(ERROR_TUNE<<8);
+			free(cmdseq->props);
 			free(cmdseq);
 			return -1;
 		}
@@ -1520,6 +1521,7 @@ default:
 		if ((ioctl(fd_frontend, FE_SET_PROPERTY, &cmdclear)) == -1) {
 			log_message( log_module,  MSG_ERROR,"FE_SET_PROPERTY clear failed : %s\n", strerror(errno));
 			set_interrupted(ERROR_TUNE<<8);
+			free(cmdseq->props);
 			free(cmdseq);
 			return -1;
 		}
@@ -1527,9 +1529,11 @@ default:
 		if ((ioctl(fd_frontend, FE_SET_PROPERTY, cmdseq)) == -1) {
 			log_message( log_module,  MSG_ERROR,"FE_SET_PROPERTY failed : %s\n", strerror(errno));
 			set_interrupted(ERROR_TUNE<<8);
+			free(cmdseq->props);
 			free(cmdseq);
 			return -1;
 		}
+		free(cmdseq->props);
 		free(cmdseq);
 
 		}

--- a/src/tune.c
+++ b/src/tune.c
@@ -1,7 +1,7 @@
 /* MuMuDVB - Stream a DVB transport stream.
  * File for tuning DVB cards
  *
- * last version availaible from http://mumudvb.braice.net/
+ * last version availaible from http://mumudvb.net/
  *
  * Copyright (C) 2004-2013 Brice DUBOST
  * Copyright (C) Dave Chapman 2001,2002

--- a/src/unicast_clients.c
+++ b/src/unicast_clients.c
@@ -75,7 +75,7 @@ unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct 
 	if(unicast_vars->clients==NULL)
 	{
 		log_message( log_module, MSG_FLOOD,"first client\n");
-		client=unicast_vars->clients=malloc(sizeof(unicast_client_t));
+		client=unicast_vars->clients=calloc(1, sizeof(unicast_client_t));
 		prev_client=NULL;
 	}
 	else
@@ -84,7 +84,7 @@ unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct 
 		client=unicast_vars->clients;
 		while(client->next!=NULL)
 			client=client->next;
-		client->next=malloc(sizeof(unicast_client_t));
+		client->next=calloc(1, sizeof(unicast_client_t));
 		prev_client=client;
 		client=client->next;
 	}

--- a/src/unicast_clients.c
+++ b/src/unicast_clients.c
@@ -3,7 +3,7 @@
  *
  * (C) 2009 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -3,7 +3,7 @@
  *
  * (C) 2009-2013 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/unicast_monit.c
+++ b/src/unicast_monit.c
@@ -3,7 +3,7 @@
  *
  * (C) 2013 Brice DUBOST
  *
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  *
  * Copyright notice:
  *

--- a/src/unicast_queue.c
+++ b/src/unicast_queue.c
@@ -3,7 +3,7 @@
  * 
  * (C) 2009 Brice DUBOST
  * 
- * The latest version can be found at http://mumudvb.braice.net
+ * The latest version can be found at http://mumudvb.net
  * 
  * Copyright notice:
  * 


### PR DESCRIPTION
Not all are fixed. At least four is still here:

==2348== HEAP SUMMARY:
==2348==     in use at exit: 5,882,890 bytes in 383 blocks
==2348==   total heap usage: 8,752 allocs, 8,369 frees, 8,360,882 bytes allocated
==2348==
==2348== Searching for pointers to 383 not-freed blocks
==2348== Checked 428,288 bytes
==2348== 
==2348== 14 bytes in 1 blocks are definitely lost in loss record 1 of 6
==2348==    at 0x482A569: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==2348==    by 0x482C9D8: realloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==2348==    by 0x116A42: mumu_string_append (mumudvb_common.c:244)
==2348==    by 0x135771: init_cam_v (cam.c:154)
==2348==    by 0x1109E3: main (mumudvb.c:226)
==2348==   
==2348== 24 bytes in 1 blocks are definitely lost in loss record 2 of 6
==2348==    at 0x482C931: realloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==2348==    by 0x1268F8: unicast_close_connection (unicast_http.c:547)
==2348==    by 0x126362: unicast_handle_fd_event (unicast_http.c:423)
==2348==    by 0x11367F: main (mumudvb.c:1348)
==2348==
==2348== 181,500 bytes in 11 blocks are possibly lost in loss record 4 of 6
==2348==    at 0x482C712: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==2348==    by 0x11B8DF: eit_rewrite_new_global_packet (rewrite_eit.c:297)
==2348==    by 0x113DC2: main (mumudvb.c:1531)
==2348==
==2348== 5,701,352 (2,084 direct, 5,699,268 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6
==2348==    at 0x482C712: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==2348==    by 0x11B350: eit_new_packet (rewrite_eit.c:142)
==2348==    by 0x11B7C7: eit_rewrite_new_global_packet (rewrite_eit.c:275)
==2348==    by 0x113DC2: main (mumudvb.c:1531)
==2348==
==2348== LEAK SUMMARY:
==2348==    definitely lost: 2,122 bytes in 3 blocks
==2348==    indirectly lost: 5,699,268 bytes in 369 blocks
==2348==      possibly lost: 181,500 bytes in 11 blocks
==2348==    still reachable: 0 bytes in 0 blocks
==2348==         suppressed: 0 bytes in 0 blocks
