### PR TITLE
EIT: fix start date key name and value

### DIFF
--- a/src/unicast_EIT.c
+++ b/src/unicast_EIT.c
@@ -208,7 +208,7 @@ void eit_display_contents(mumudvb_ts_packet_t *full_eit, struct unicast_reply* r
 		Y=YY+K+1900;
 		M=MM-1-K*12;
 
-		unicast_reply_write(reply, "\t\t\"start_time day \" : \"%d-%02d-%02d (yy-mm-dd)\",\n",
+		unicast_reply_write(reply, "\t\t\"start_date\" : \"%d-%02d-%02d\",\n",
 						Y,M,D);
 		//compute hours
 		int hh,mm,ss;


### PR DESCRIPTION
"start_time day " (with the space on the end) is not the best name for a JSON key holding the start date.
Also, " (yy-mm-dd)" feels a little bit redundant and doesn't look very nice.

I just found this out while working on my EIT parser, so I decided to patch it and share with upstream.