### PR TITLE
Fix infinite loop on write error in unicast_reply_send

### DIFF
--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -1074,8 +1074,13 @@ int unicast_reply_send(struct unicast_reply *reply, int socket, int code, const 
 	//now we write the data
 	while (size<reply->used_header){
 		temp_size = write(socket, reply->buffer_header+size, reply->used_header-size);
-		size += temp_size!=-1 ? temp_size : 0 ;
-
+		if (temp_size != -1) {
+			size += temp_size;
+		} else {
+			if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
+				return -1;
+			}
+		}
 	}
 	return size;
 }


### PR DESCRIPTION
Sometimes mumudvb would get stuck in this write loop when the HTTP socket disconnects before the response can be written (race condition that doesn't often appear outside EIT responses).

- Since the sockets are non-blocking, we need to busy-wait when no data can be written but the socket is still valid. Blocking sockets would be nicer but that's not easy here. This matches current behavior.
- The return value of this method does not seem to be used anywhere, so -1 seems like a safe and sane choice for an error value. errno is also not reset, so clients could in theory see what error occurred (though none do at the moment).