### PR TITLE
Fix setting voltage to OFF instead of 13v after sending JESS/Unicable…

### DIFF
--- a/src/tune.c
+++ b/src/tune.c
@@ -741,7 +741,7 @@ static int diseqc_send_msg(int fd, fe_sec_voltage_t v, struct diseqc_cmd **cmd, 
 		log_message( log_module,  MSG_WARN, "problem Setting the Tone OFF\n");
 		return -1;
 	}
-	if (switch_type=='N')
+	if (switch_type=='N'||switch_type=='J')
 	{
 		if((err = ioctl(fd, FE_SET_VOLTAGE, SEC_VOLTAGE_18)))
 		{
@@ -754,7 +754,7 @@ static int diseqc_send_msg(int fd, fe_sec_voltage_t v, struct diseqc_cmd **cmd, 
 		return -1;
 	}
 	msleep(15);
-	if (switch_type=='N') //Extra time for Unicable
+	if (switch_type=='N'||switch_type=='J') //Extra time for Unicable
 		msleep(65);
 	//1.x compatible equipment
 	while (*cmd) {
@@ -781,6 +781,14 @@ static int diseqc_send_msg(int fd, fe_sec_voltage_t v, struct diseqc_cmd **cmd, 
 				return -1;
 			}
 		}
+                else if (switch_type=='J')
+                {
+                        if((err = ioctl(fd, FE_SET_VOLTAGE, SEC_VOLTAGE_OFF)))
+                        {
+                                log_message( log_module,  MSG_WARN, "problem Setting the Voltage\n");
+                                return -1;
+                        }
+                }
 
 		if(diseqc_repeat)
 		{
@@ -802,7 +810,7 @@ static int diseqc_send_msg(int fd, fe_sec_voltage_t v, struct diseqc_cmd **cmd, 
 	}
 
 	msleep(15);
-	if (switch_type=='N') //Extra time for Unicable
+	if (switch_type=='N'||switch_type=='J') //Extra time for Unicable
 		msleep(65);
 	if ((err = ioctl(fd, FE_DISEQC_SEND_BURST, b)))
 	{
@@ -810,7 +818,7 @@ static int diseqc_send_msg(int fd, fe_sec_voltage_t v, struct diseqc_cmd **cmd, 
 		return err;
 	}
 	msleep(15);
-	if (switch_type=='N') //Extra time for Unicable
+	if (switch_type=='N'||switch_type=='J') //Extra time for Unicable
 		msleep(65);
 
 	if(ioctl(fd, FE_SET_TONE, t) < 0)

--- a/src/unicast_monit.c
+++ b/src/unicast_monit.c
@@ -382,7 +382,7 @@ unicast_send_json_state (int number_of_channels, mumudvb_channel_t *channels, in
 	unicast_reply_write(reply, "\t\"frontend_tuned\" : %d ,\n",strengthparams->tune_p->card_tuned);
 	if (strengthparams->tune_p->fe_type==FE_QPSK) // Do some test for always showing frequency in kHz
 	{
-		unicast_reply_write(reply, "\t\"frontend_frequency\" : %d,\n",strengthparams->tune_p->freq);
+		unicast_reply_write(reply, "\t\"frontend_frequency\" : %f,\n",strengthparams->tune_p->freq);
 		unicast_reply_write(reply, "\t\"frontend_satnumber\" : %d,\n",strengthparams->tune_p->sat_number);
 	}
 	else


### PR DESCRIPTION
Had some strange behavior not able to tune on second system with S8 tuner card on Unicable Inverto MSW setup. Fixed it with setting the voltage off after send msg instead of leaving it on low voltage (13v). That fixed the issue.