### PR TITLE
increase SDT len

### DIFF
--- a/src/ts.h
+++ b/src/ts.h
@@ -294,7 +294,7 @@ typedef struct {
 
 
 /** length of the SDT header */
-#define SDT_LEN 11
+#define SDT_LEN 99
 
 /** @brief Service Description Table (SDT):
  *


### PR DESCRIPTION
some Transponder have a much higher count of Services than 12 entries.
For example 
Astra 19.2E 12363 V -> 40
Astra 19.2E 12266 H -> 65

So a much higher limit is needed for transmitting all SDT Entries
