### PR TITLE
Fix software descrambing when CA_SET_PID is not available

### DIFF
--- a/src/scam_common.h
+++ b/src/scam_common.h
@@ -68,8 +68,10 @@ typedef struct ca_pid {
 	unsigned int pid;
 	int index;      /* -1 == disable*/
 	} ca_pid_t;
-//We should not be able to get it so a number that is unlikely to happen
-#define CA_SET_PID 42424242
+// In older kernels < 4.14, CA_SET_PID was _IOW('o', 135, ca_pid_t) really.
+// Oscam defines it as a fixed integer value in module-dvbapi.h file
+// under DVBAPI_CA_SET_PID macro.
+#define CA_SET_PID 0x40086F87
 #endif
 
 


### PR DESCRIPTION
Mumudvb cannot get CA_SET_PID request because the workaround 596f7db fails to define the historical ioctl command for it. Thus, this workaround has never worked and software descrambing was broken since removal of CA_SET_PID from recent kernels.

We can set it properly by the kernel way `_IOW('o', 135, ca_pid_t)` or by the oscam way (see DVBAPI_CA_SET_PID in module-dvbapi.h file) as a constant.

The oscam way is the safest way because we can do match the mumudvb's constant to the oscam's constant being independent to any compilation issue.

 Fixes #258, #195