### PR TITLE
Add support for compiling on win32, fixes for obsolete api usage (inet_ntoa and friends), allow building without dvb-api, fixing compile warnings, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ config.*
 *.sw[po]
 .vs/
 MuMuDVB.vcxproj.user
+Debug/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ config.*
 /src/stamp-h1
 *.o
 *.sw[po]
+.vs/
+MuMuDVB.vcxproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config.*
 .vs/
 MuMuDVB.vcxproj.user
 Debug/
+Release/

--- a/MuMuDVB.sln
+++ b/MuMuDVB.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32210.238
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MuMuDVB", "MuMuDVB.vcxproj", "{05FE9671-56C3-4F65-B008-29C8307DA3B9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{05FE9671-56C3-4F65-B008-29C8307DA3B9}.Debug|x64.ActiveCfg = Debug|x64
+		{05FE9671-56C3-4F65-B008-29C8307DA3B9}.Debug|x64.Build.0 = Debug|x64
+		{05FE9671-56C3-4F65-B008-29C8307DA3B9}.Debug|x86.ActiveCfg = Debug|Win32
+		{05FE9671-56C3-4F65-B008-29C8307DA3B9}.Debug|x86.Build.0 = Debug|Win32
+		{05FE9671-56C3-4F65-B008-29C8307DA3B9}.Release|x64.ActiveCfg = Release|x64
+		{05FE9671-56C3-4F65-B008-29C8307DA3B9}.Release|x64.Build.0 = Release|x64
+		{05FE9671-56C3-4F65-B008-29C8307DA3B9}.Release|x86.ActiveCfg = Release|Win32
+		{05FE9671-56C3-4F65-B008-29C8307DA3B9}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1DFB6EE4-C7EE-4D38-BF47-9DBCE84E3FEF}
+	EndGlobalSection
+EndGlobal

--- a/MuMuDVB.vcxproj
+++ b/MuMuDVB.vcxproj
@@ -22,15 +22,16 @@
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{05FE9671-56C3-4F65-B008-29C8307DA3B9}</ProjectGuid>
     <Keyword>MakeFileProj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Makefile</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Makefile</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
@@ -64,11 +65,49 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <NMakePreprocessorDefinitions>WIN32;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);pthread\include;src</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);pthread\lib</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <NMakePreprocessorDefinitions>WIN32;NDEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);pthread\include;src</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);pthread\lib</LibraryPath>
   </PropertyGroup>
-  <ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);pthread\include;src</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);pthread\include;src</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0A00</PreprocessorDefinitions>
+      <WarningLevel>Level3</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);pthread_static_lib.lib;ws2_32.lib;Iphlpapi.lib</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0A00</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0A00</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);pthread_static_lib.lib;ws2_32.lib;Iphlpapi.lib</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0A00</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\autoconf.c" />
@@ -78,9 +117,15 @@
     <ClCompile Include="src\autoconf_pat.c" />
     <ClCompile Include="src\autoconf_pmt.c" />
     <ClCompile Include="src\autoconf_sdt.c" />
-    <ClCompile Include="src\cam.c" />
+    <ClCompile Include="src\cam.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="src\crc32.c" />
     <ClCompile Include="src\dvb.c" />
+    <ClCompile Include="src\getopt.c" />
     <ClCompile Include="src\log.c" />
     <ClCompile Include="src\multicast.c" />
     <ClCompile Include="src\mumudvb.c" />
@@ -95,11 +140,36 @@
     <ClCompile Include="src\rewrite_sdt.c" />
     <ClCompile Include="src\rtp.c" />
     <ClCompile Include="src\sap.c" />
-    <ClCompile Include="src\scam_capmt.c" />
-    <ClCompile Include="src\scam_common.c" />
-    <ClCompile Include="src\scam_decsa.c" />
-    <ClCompile Include="src\scam_getcw.c" />
-    <ClCompile Include="src\scam_send.c" />
+    <ClCompile Include="src\scam_capmt.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="src\scam_common.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="src\scam_decsa.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="src\scam_getcw.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="src\scam_send.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="src\t2mi.c" />
     <ClCompile Include="src\ts.c" />
     <ClCompile Include="src\tune.c" />
@@ -108,6 +178,7 @@
     <ClCompile Include="src\unicast_http.c" />
     <ClCompile Include="src\unicast_monit.c" />
     <ClCompile Include="src\unicast_queue.c" />
+    <ClCompile Include="src\win32.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\autoconf.h" />
@@ -115,6 +186,7 @@
     <ClInclude Include="src\config.h" />
     <ClInclude Include="src\dvb.h" />
     <ClInclude Include="src\errors.h" />
+    <ClInclude Include="src\getopt.h" />
     <ClInclude Include="src\log.h" />
     <ClInclude Include="src\mumudvb.h" />
     <ClInclude Include="src\mumudvb_mon.h" />
@@ -131,6 +203,7 @@
     <ClInclude Include="src\tune.h" />
     <ClInclude Include="src\unicast_http.h" />
     <ClInclude Include="src\unicast_queue.h" />
+    <ClInclude Include="src\win32.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/MuMuDVB.vcxproj
+++ b/MuMuDVB.vcxproj
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{05FE9671-56C3-4F65-B008-29C8307DA3B9}</ProjectGuid>
+    <Keyword>MakeFileProj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <NMakePreprocessorDefinitions>WIN32;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <NMakePreprocessorDefinitions>WIN32;NDEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="src\autoconf.c" />
+    <ClCompile Include="src\autoconf_atsc.c" />
+    <ClCompile Include="src\autoconf_cat.c" />
+    <ClCompile Include="src\autoconf_nit.c" />
+    <ClCompile Include="src\autoconf_pat.c" />
+    <ClCompile Include="src\autoconf_pmt.c" />
+    <ClCompile Include="src\autoconf_sdt.c" />
+    <ClCompile Include="src\cam.c" />
+    <ClCompile Include="src\crc32.c" />
+    <ClCompile Include="src\dvb.c" />
+    <ClCompile Include="src\log.c" />
+    <ClCompile Include="src\multicast.c" />
+    <ClCompile Include="src\mumudvb.c" />
+    <ClCompile Include="src\mumudvb_channels.c" />
+    <ClCompile Include="src\mumudvb_common.c" />
+    <ClCompile Include="src\mumudvb_mon.c" />
+    <ClCompile Include="src\network.c" />
+    <ClCompile Include="src\rewrite.c" />
+    <ClCompile Include="src\rewrite_eit.c" />
+    <ClCompile Include="src\rewrite_pat.c" />
+    <ClCompile Include="src\rewrite_pmt.c" />
+    <ClCompile Include="src\rewrite_sdt.c" />
+    <ClCompile Include="src\rtp.c" />
+    <ClCompile Include="src\sap.c" />
+    <ClCompile Include="src\scam_capmt.c" />
+    <ClCompile Include="src\scam_common.c" />
+    <ClCompile Include="src\scam_decsa.c" />
+    <ClCompile Include="src\scam_getcw.c" />
+    <ClCompile Include="src\scam_send.c" />
+    <ClCompile Include="src\t2mi.c" />
+    <ClCompile Include="src\ts.c" />
+    <ClCompile Include="src\tune.c" />
+    <ClCompile Include="src\unicast_clients.c" />
+    <ClCompile Include="src\unicast_EIT.c" />
+    <ClCompile Include="src\unicast_http.c" />
+    <ClCompile Include="src\unicast_monit.c" />
+    <ClCompile Include="src\unicast_queue.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\autoconf.h" />
+    <ClInclude Include="src\cam.h" />
+    <ClInclude Include="src\config.h" />
+    <ClInclude Include="src\dvb.h" />
+    <ClInclude Include="src\errors.h" />
+    <ClInclude Include="src\log.h" />
+    <ClInclude Include="src\mumudvb.h" />
+    <ClInclude Include="src\mumudvb_mon.h" />
+    <ClInclude Include="src\network.h" />
+    <ClInclude Include="src\rewrite.h" />
+    <ClInclude Include="src\rtp.h" />
+    <ClInclude Include="src\sap.h" />
+    <ClInclude Include="src\scam_capmt.h" />
+    <ClInclude Include="src\scam_common.h" />
+    <ClInclude Include="src\scam_decsa.h" />
+    <ClInclude Include="src\scam_getcw.h" />
+    <ClInclude Include="src\scam_send.h" />
+    <ClInclude Include="src\ts.h" />
+    <ClInclude Include="src\tune.h" />
+    <ClInclude Include="src\unicast_http.h" />
+    <ClInclude Include="src\unicast_queue.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/MuMuDVB.vcxproj
+++ b/MuMuDVB.vcxproj
@@ -124,7 +124,13 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="src\crc32.c" />
-    <ClCompile Include="src\dvb.c" />
+    <ClCompile Include="src\dvb.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="src\dvb_win32.c" />
     <ClCompile Include="src\getopt.c" />
     <ClCompile Include="src\log.c" />
     <ClCompile Include="src\multicast.c" />

--- a/MuMuDVB.vcxproj.filters
+++ b/MuMuDVB.vcxproj.filters
@@ -1,0 +1,195 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\autoconf.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\autoconf_atsc.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\autoconf_cat.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\autoconf_nit.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\autoconf_pat.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\autoconf_pmt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\autoconf_sdt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\cam.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\crc32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\dvb.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\log.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\multicast.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\mumudvb.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\mumudvb_channels.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\mumudvb_common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\mumudvb_mon.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\network.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rewrite.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rewrite_eit.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rewrite_pat.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rewrite_pmt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rewrite_sdt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rtp.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sap.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\scam_capmt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\scam_common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\scam_decsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\scam_getcw.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\scam_send.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\t2mi.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ts.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\tune.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\unicast_clients.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\unicast_EIT.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\unicast_http.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\unicast_monit.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\unicast_queue.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\autoconf.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\cam.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dvb.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\errors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\mumudvb.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\mumudvb_mon.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\network.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\rewrite.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\rtp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\sap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\scam_capmt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\scam_common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\scam_decsa.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\scam_getcw.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\scam_send.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ts.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\tune.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\unicast_http.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\unicast_queue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/MuMuDVB.vcxproj.filters
+++ b/MuMuDVB.vcxproj.filters
@@ -126,6 +126,12 @@
     <ClCompile Include="src\unicast_queue.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\getopt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\win32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\autoconf.h">
@@ -189,6 +195,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\unicast_queue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\getopt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\win32.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MuMuDVB.vcxproj.filters
+++ b/MuMuDVB.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClCompile Include="src\win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\dvb_win32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\autoconf.h">

--- a/configure.ac
+++ b/configure.ac
@@ -12,14 +12,14 @@ dnl Check for linux dvb api headers
 dnl
 AC_CHECK_HEADER([linux/dvb/dmx.h])
 if test "$ac_cv_header_linux_dvb_dmx_h" = no; then
-        AC_MSG_ERROR([linux dvb api headers are required to build])
+        AC_MSG_WARN([linux dvb api headers not found, disabling dvb api functionality])
+        AC_DEFINE(DISABLE_DVB_API, 1, Define if you want to bulid without DVB API)
 fi
 
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
-AC_PROG_CC_C99
 
 dnl
 dnl Iconv stuff

--- a/doc/README.win32
+++ b/doc/README.win32
@@ -1,0 +1,19 @@
+To build under windows (tested with VS2022)
+
+* copy src/config_win32.h to src/config.h
+* build pthread-win32 and place its release assets into pthread/lib folder.
+  inside should have, pthread_static_lib.lib (and pdb if you care)
+* only x86 build was tested and configured in the project file
+* Build as usual, either Debug or Release configuration
+
+Notes
+
+The only supported input method is file (tested) and named pipe (extensively
+tested). To send data, simply create a named pipe \\.\pipe\DVB_TUNERx where 
+x is a number 0...whatever to match 'adapter' index, and push TS data into it.
+
+CAM/SCAM is unsupported (completely skipped from build).
+
+Logging anywhere other than stdout is unsupported (no syslog/etc logging).
+
+iconv is not supported.

--- a/pthread/include/_ptw32.h
+++ b/pthread/include/_ptw32.h
@@ -1,0 +1,233 @@
+/*
+ * Module: _ptw32.h
+ *
+ * Purpose:
+ *      pthreads-win32 internal macros, to be shared by other headers
+ *      comprising the pthreads4w package.
+ *
+ * --------------------------------------------------------------------------
+ *
+ *      pthreads-win32 - POSIX Threads Library for Win32
+ *      Copyright(C) 1998 John E. Bossom
+ *      Copyright(C) 1999-2021 pthreads-win32 / pthreads4w contributors
+ *
+ *      Homepage1: http://sourceware.org/pthreads-win32/
+ *      Homepage2: http://sourceforge.net/projects/pthreads4w/
+ *
+ *      The current list of contributors is contained
+ *      in the file CONTRIBUTORS included with the source
+ *      code distribution. The list can also be seen at the
+ *      following World Wide Web location:
+ *      http://sources.redhat.com/pthreads-win32/contributors.html
+ * 
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2 of the License, or (at your option) any later version.
+ * 
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ * 
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library in the file COPYING.LIB;
+ *      if not, write to the Free Software Foundation, Inc.,
+ *      59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+ *
+ * --------------------------------------------------------------------------
+ */
+
+#ifndef PTW32_H
+#define PTW32_H
+
+/* See the README file for an explanation of the pthreads4w
+ * version numbering scheme and how the DLL is named etc.
+ */
+#define  PTW32_VERSION_MAJOR 3
+#define  PTW32_VERSION_MINOR 0
+#define  PTW32_VERSION_MICRO 3
+#define  PTW32_VERION_BUILD 1
+#define  PTW32_VERSION 3,0,3,1
+#define  PTW32_VERSION_STRING "3, 0, 3, 1\0"
+
+// skip the rest when running this through the Microsoft Resource Compiler, which is a VERY brittle piece of machinery! -> RC2188 & RC1116 cryptic failures will be your part! 
+#ifndef RC_INVOKED
+
+#if defined(__GNUC__)
+# pragma GCC system_header
+# if ! defined __declspec
+#  error "Please upgrade your GNU compiler to one that supports __declspec."
+# endif
+#endif
+
+#if defined (__cplusplus)
+# define PTW32_BEGIN_C_DECLS  extern "C" {
+# define PTW32_END_C_DECLS    }
+#else
+# define PTW32_BEGIN_C_DECLS
+# define PTW32_END_C_DECLS
+#endif
+
+#if defined PTW32_STATIC_LIB
+# define PTW32_DLLPORT
+
+#elif defined  PTW32_BUILD
+# define  PTW32_DLLPORT __declspec (dllexport)
+#else
+# define  PTW32_DLLPORT /*__declspec (dllimport)*/
+#endif
+
+#ifndef  PTW32_CDECL
+/* FIXME: another internal macro; should have two initial underscores;
+ * Nominally, we prefer to use __cdecl calling convention for all our
+ * functions, but we map it through this macro alias to facilitate the
+ * possible choice of alternatives; for example:
+ */
+# ifdef _OPEN_WATCOM_SOURCE
+  /* The Open Watcom C/C++ compiler uses a non-standard default calling
+   * convention, (similar to __fastcall), which passes function arguments
+   * in registers, unless the __cdecl convention is explicitly specified
+   * in exposed function prototypes.
+   *
+   * Our preference is to specify the __cdecl convention for all calls,
+   * even though this could slow Watcom code down slightly.  If you know
+   * that the Watcom compiler will be used to build both the DLL and your
+   * application, then you may #define _OPEN_WATCOM_SOURCE, so disabling
+   * the forced specification of __cdecl for all function declarations;
+   * remember that this must be defined consistently, for both the DLL
+   * build, and the application build.
+   */
+#  define  PTW32_CDECL
+# else
+#  define  PTW32_CDECL __cdecl
+# endif
+#endif
+
+/*
+ * This is more or less a duplicate of what is in the autoconf config.h,
+ * which is only used when building the pthreads4w libraries.
+ */
+
+#if !defined (PTW32_CONFIG_H) && !defined(PTW32_PSEUDO_CONFIG_H_SOURCED)
+#  define PTW32_PSEUDO_CONFIG_H_SOURCED
+#  if defined(WINCE)
+#    undef  HAVE_CPU_AFFINITY
+#    define NEED_DUPLICATEHANDLE
+#    define NEED_CREATETHREAD
+#    define NEED_ERRNO
+#    define NEED_CALLOC
+#    define NEED_UNICODE_CONSTS
+#    define NEED_PROCESS_AFFINITY_MASK
+/* This may not be needed */
+#    define RETAIN_WSALASTERROR
+#  elif defined(_MSC_VER)
+#    if _MSC_VER >= 1900
+#      define HAVE_STRUCT_TIMESPEC
+#    elif _MSC_VER < 1300
+#      define  PTW32_CONFIG_MSVC6
+#    elif _MSC_VER < 1400
+#      define  PTW32_CONFIG_MSVC7
+#    endif
+#  elif defined(_UWIN)
+#    define HAVE_MODE_T
+#    define HAVE_STRUCT_TIMESPEC
+#    define HAVE_SIGNAL_H
+#  elif defined(__MINGW64__)
+#    define HAVE_STRUCT_TIMESPEC
+#    define HAVE_MODE_T
+#  elif defined(__MINGW32__)
+#    define HAVE_MODE_T
+#  endif
+#endif
+
+#if !defined(_WIN32_WINNT)
+# define _WIN32_WINNT 0x0400
+#endif
+
+/*
+ * If HAVE_ERRNO_H is defined then assume that autoconf has been used
+ * to overwrite config.h, otherwise the original config.h is in use
+ * at build-time or the above block of defines is in use otherwise
+ * and NEED_ERRNO is either defined or not defined.
+ */
+#if defined(HAVE_ERRNO_H) || !defined(NEED_ERRNO)
+#  include <errno.h>
+#else
+#  include "need_errno.h"
+#endif
+
+#if defined(__BORLANDC__)
+#  define int64_t LONGLONG
+#  define uint64_t ULONGLONG
+#elif !defined(__MINGW32__)
+     typedef _int64 int64_t;
+     typedef unsigned _int64 uint64_t;
+#  if defined (PTW32_CONFIG_MSVC6)
+     typedef long intptr_t;
+#  endif
+#elif defined(HAVE_STDINT_H) && HAVE_STDINT_H == 1
+#  include <stdint.h>
+#endif
+
+/*
+ * In case ETIMEDOUT hasn't been defined above somehow.
+ */
+#if !defined(ETIMEDOUT)
+  /*
+   * note: ETIMEDOUT is no longer defined in winsock.h
+   * WSAETIMEDOUT is so use its value.
+   */
+#  include <winsock.h>
+#  if defined(WSAETIMEDOUT)
+#    define ETIMEDOUT WSAETIMEDOUT
+#  else
+#   define ETIMEDOUT 10060	/* This is the value of WSAETIMEDOUT in winsock.h. */
+#  endif
+#endif
+
+/*
+ * Several systems may not define some error numbers;
+ * defining those which are likely to be missing here will let
+ * us complete the library builds.
+ */
+#if !defined(ENOTSUP)
+#  define ENOTSUP 48   /* This is the value in Solaris. */
+#endif
+
+#if !defined(ETIMEDOUT)
+#  define ETIMEDOUT 10060 /* Same as WSAETIMEDOUT */
+#endif
+
+#if !defined(ENOSYS)
+#  define ENOSYS 140     /* Semi-arbitrary value */
+#endif
+
+#if !defined(EDEADLK)
+#  if defined(EDEADLOCK)
+#    define EDEADLK EDEADLOCK
+#  else
+#    define EDEADLK 36     /* This is the value in MSVC. */
+#  endif
+#endif
+
+/* POSIX 2008 - related to robust mutexes */
+#if  PTW32_VERSION_MAJOR > 2
+#  if !defined(EOWNERDEAD)
+#    define EOWNERDEAD 1000
+#  endif
+#  if !defined(ENOTRECOVERABLE)
+#    define ENOTRECOVERABLE 1001
+#  endif
+#else
+#  if !defined(EOWNERDEAD)
+#    define EOWNERDEAD 42
+#  endif
+#  if !defined(ENOTRECOVERABLE)
+#    define ENOTRECOVERABLE 43
+#  endif
+#endif
+
+#endif // RC_INVOKED
+
+#endif	/* !PTW32_H */

--- a/pthread/include/pthread.h
+++ b/pthread/include/pthread.h
@@ -1,0 +1,1260 @@
+/* This is an implementation of the threads API of the Single Unix Specification.
+ *
+ * --------------------------------------------------------------------------
+ *
+ *      pthreads-win32 - POSIX Threads Library for Win32
+ *      Copyright(C) 1998 John E. Bossom
+ *      Copyright(C) 1999-2021 pthreads-win32 / pthreads4w contributors
+ *
+ *      Homepage1: http://sourceware.org/pthreads-win32/
+ *      Homepage2: http://sourceforge.net/projects/pthreads4w/
+ *
+ *      The current list of contributors is contained
+ *      in the file CONTRIBUTORS included with the source
+ *      code distribution. The list can also be seen at the
+ *      following World Wide Web location:
+ *      http://sources.redhat.com/pthreads-win32/contributors.html
+ * 
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2 of the License, or (at your option) any later version.
+ * 
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ * 
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library in the file COPYING.LIB;
+ *      if not, write to the Free Software Foundation, Inc.,
+ *      59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+ *
+ * --------------------------------------------------------------------------
+ */
+#pragma once
+#if !defined( PTHREAD_H )
+#define PTHREAD_H
+
+/* There are three implementations of cancel cleanup.
+ * Note that pthread.h is included in both application
+ * compilation units and also internally for the library.
+ * The code here and within the library aims to work
+ * for all reasonable combinations of environments.
+ *
+ * The three implementations are:
+ *
+ *   WIN32 SEH
+ *   C
+ *   C++
+ *
+ * Please note that exiting a push/pop block via
+ * "return", "exit", "break", or "continue" will
+ * lead to different behaviour amongst applications
+ * depending upon whether the library was built
+ * using SEH, C++, or C. For example, a library built
+ * with SEH will call the cleanup routine, while both
+ * C++ and C built versions will not.
+ */
+
+/*
+ * Define defaults for cleanup code.
+ * Note: Unless the build explicitly defines one of the following, then
+ * we default to standard C style cleanup. This style uses setjmp/longjmp
+ * in the cancellation and thread exit implementations and therefore won't
+ * do stack unwinding if linked to applications that have it (e.g.
+ * C++ apps). This is currently consistent with most/all commercial Unix
+ * POSIX threads implementations.
+ */
+#if !defined( PTW32_CLEANUP_SEH ) && !defined( PTW32_CLEANUP_CXX ) && !defined( PTW32_CLEANUP_C )
+/*
+   [i_a] fix for apps using pthreads-Win32: when they do not define PTW32_CLEANUP_SEH themselves,
+         they're screwed as they'll receive the 'PTW32_CLEANUP_C' macros which do NOT work when
+		 the pthreads library code itself has actually been build with PTW32_CLEANUP_SEH,
+		 which is the case when building this stuff in MSVC.
+
+		 Hence this section is made to 'sensibly autodetect' the cleanup mode, when it hasn't
+		 been hardwired in the makefiles / project files.
+
+		 After all, who expects he MUST define one of these PTW32_CLEANUP_XXX defines in his own
+		 code when using pthreads-Win32, for whatever reason.
+ */
+#if (defined(_MSC_VER) || defined(PTW32_RC_MSC))
+#define PTW32_CLEANUP_SEH
+#elif defined(__cplusplus)
+#define PTW32_CLEANUP_CXX
+#else
+# define PTW32_CLEANUP_C
+#endif
+#endif // SEH || CXX || C
+
+#if defined( PTW32_CLEANUP_SEH ) && ( !defined( _MSC_VER ) && !defined (PTW32_RC_MSC))
+#error ERROR [__FILE__, line __LINE__]: SEH is not supported for this compiler.
+#endif
+
+#include "_ptw32.h"
+
+/*
+ * Stop here if we are being included by the resource compiler.
+ */
+#if !defined(RC_INVOKED)
+
+#undef  PTW32_LEVEL
+#undef  PTW32_LEVEL_MAX
+#define PTW32_LEVEL_MAX  3
+
+#if _POSIX_C_SOURCE >= 200112L			/* POSIX.1-2001 and later */
+# define PTW32_LEVEL  PTW32_LEVEL_MAX	/* include everything     */
+
+#elif defined INCLUDE_NP			/* earlier than POSIX.1-2001, but... */
+# define PTW32_LEVEL  2			/* include non-portable extensions   */
+
+#elif _POSIX_C_SOURCE >= 199309L		/* POSIX.1-1993           */
+# define PTW32_LEVEL  1 			/* include 1b, 1c, and 1d */
+
+#elif defined _POSIX_SOURCE			/* early POSIX     */
+# define PTW32_LEVEL  0			/* minimal support */
+
+#else						/* unspecified support level */
+# define PTW32_LEVEL  PTW32_LEVEL_MAX	/* include everything anyway */
+#endif
+
+/*
+ * -------------------------------------------------------------
+ *
+ *
+ * Module: pthread.h
+ *
+ * Purpose:
+ *      Provides an implementation of PThreads based upon the
+ *      standard:
+ *
+ *              POSIX 1003.1-2001
+ *  and
+ *    The Single Unix Specification version 3
+ *
+ *    (these two are equivalent)
+ *
+ *      in order to enhance code portability between Windows,
+ *  various commercial Unix implementations, and Linux.
+ *
+ *      See the ANNOUNCE file for a full list of conforming
+ *      routines and defined constants, and a list of missing
+ *      routines and constants not defined in this implementation.
+ *
+ * Authors:
+ *      There have been many contributors to this library.
+ *      The initial implementation was contributed by
+ *      John Bossom, and several others have provided major
+ *      sections or revisions of parts of the implementation.
+ *      Often significant effort has been contributed to
+ *      find and fix important bugs and other problems to
+ *      improve the reliability of the library, which sometimes
+ *      is not reflected in the amount of code which changed as
+ *      result.
+ *      As much as possible, the contributors are acknowledged
+ *      in the ChangeLog file in the source code distribution
+ *      where their changes are noted in detail.
+ *
+ *      Contributors are listed in the CONTRIBUTORS file.
+ *
+ *      As usual, all bouquets go to the contributors, and all
+ *      brickbats go to the project maintainer.
+ *
+ * Maintainer:
+ *      The code base for this project is coordinated and
+ *      eventually pre-tested, packaged, and made available by
+ *
+ *              Ross Johnson <rpj@callisto.canberra.edu.au>
+ *
+ * QA Testers:
+ *      Ultimately, the library is tested in the real world by
+ *      a host of competent and demanding scientists and
+ *      engineers who report bugs and/or provide solutions
+ *      which are then fixed or incorporated into subsequent
+ *      versions of the library. Each time a bug is fixed, a
+ *      test case is written to prove the fix and ensure
+ *      that later changes to the code don't reintroduce the
+ *      same error. The number of test cases is slowly growing
+ *      and therefore so is the code reliability.
+ *
+ * Compliance:
+ *      See the file ANNOUNCE for the list of implemented
+ *      and not-implemented routines and defined options.
+ *      Of course, these are all defined is this file as well.
+ *
+ * Web site:
+ *      The source code and other information about this library
+ *      are available from
+ *
+ *              http://sources.redhat.com/pthreads-win32/
+ *
+ * -------------------------------------------------------------
+ */
+
+/*
+ * Boolean values to make us independent of system includes.
+ */
+enum
+{ 
+  PTW32_FALSE = 0,
+  PTW32_TRUE = (! PTW32_FALSE)
+};
+
+#include <time.h>
+#include "sched.h"
+
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+# define HAVE_STRUCT_TIMESPEC
+# ifndef _TIMESPEC_DEFINED
+#  define _TIMESPEC_DEFINED
+# endif
+#endif
+
+/*
+ * -------------------------------------------------------------
+ *
+ * POSIX 1003.1-2001 Options
+ * =========================
+ *
+ * Options are normally set in <unistd.h>, which is not provided
+ * with pthreads-win32.
+ *
+ * For conformance with the Single Unix Specification (version 3), all of the
+ * options below are defined, and have a value of either -1 (not supported)
+ * or yyyymm[dd]L (supported).
+ *
+ * These options can neither be left undefined nor have a value of 0, because
+ * either indicates that sysconf(), which is not implemented, may be used at
+ * runtime to check the status of the option.
+ *
+ * _POSIX_THREADS (== 20080912L)
+ *                      If == 20080912L, you can use threads
+ *
+ * _POSIX_THREAD_ATTR_STACKSIZE (== 200809L)
+ *                      If == 200809L, you can control the size of a thread's
+ *                      stack
+ *                              pthread_attr_getstacksize
+ *                              pthread_attr_setstacksize
+ *
+ * _POSIX_THREAD_ATTR_STACKADDR (== -1)
+ *                      If == 200809L, you can allocate and control a thread's
+ *                      stack. If not supported, the following functions
+ *                      will return ENOSYS, indicating they are not
+ *                      supported:
+ *                              pthread_attr_getstackaddr
+ *                              pthread_attr_setstackaddr
+ *
+ * _POSIX_THREAD_PRIORITY_SCHEDULING (== -1)
+ *                      If == 200112L, you can use realtime scheduling.
+ *                      This option indicates that the behaviour of some
+ *                      implemented functions conforms to the additional TPS
+ *                      requirements in the standard. E.g. rwlocks favour
+ *                      writers over readers when threads have equal priority.
+ *
+ * _POSIX_THREAD_PRIO_INHERIT (== -1)
+ *                      If == 200809L, you can create priority inheritance
+ *                      mutexes.
+ *                              pthread_mutexattr_getprotocol +
+ *                              pthread_mutexattr_setprotocol +
+ *
+ * _POSIX_THREAD_PRIO_PROTECT (== -1)
+ *                      If == 200809L, you can create priority ceiling mutexes
+ *                      Indicates the availability of:
+ *                              pthread_mutex_getprioceiling
+ *                              pthread_mutex_setprioceiling
+ *                              pthread_mutexattr_getprioceiling
+ *                              pthread_mutexattr_getprotocol     +
+ *                              pthread_mutexattr_setprioceiling
+ *                              pthread_mutexattr_setprotocol     +
+ *
+ * _POSIX_THREAD_PROCESS_SHARED (== -1)
+ *                      If set, you can create mutexes and condition
+ *                      variables that can be shared with another
+ *                      process.If set, indicates the availability
+ *                      of:
+ *                              pthread_mutexattr_getpshared
+ *                              pthread_mutexattr_setpshared
+ *                              pthread_condattr_getpshared
+ *                              pthread_condattr_setpshared
+ *
+ * _POSIX_THREAD_SAFE_FUNCTIONS (== 200809L)
+ *                      If == 200809L you can use the special *_r library
+ *                      functions that provide thread-safe behaviour
+ *
+ * _POSIX_READER_WRITER_LOCKS (== 200809L)
+ *                      If == 200809L, you can use read/write locks
+ *
+ * _POSIX_SPIN_LOCKS (== 200809L)
+ *                      If == 200809L, you can use spin locks
+ *
+ * _POSIX_BARRIERS (== 200809L)
+ *                      If == 200809L, you can use barriers
+ *
+ * _POSIX_ROBUST_MUTEXES (== 200809L)
+ *                      If == 200809L, you can use robust mutexes
+ *                      Officially this should also imply
+ *                      _POSIX_THREAD_PROCESS_SHARED != -1 however
+ *                      not here yet.
+ *
+ * -------------------------------------------------------------
+ */
+
+/*
+ * POSIX Options
+ */
+#undef  _POSIX_THREADS
+#define _POSIX_THREADS  200809L
+
+#undef  _POSIX_READER_WRITER_LOCKS
+#define _POSIX_READER_WRITER_LOCKS  200809L
+
+#undef  _POSIX_SPIN_LOCKS
+#define _POSIX_SPIN_LOCKS  200809L
+
+#undef  _POSIX_BARRIERS
+#define _POSIX_BARRIERS  200809L
+
+#undef  _POSIX_THREAD_SAFE_FUNCTIONS
+#define _POSIX_THREAD_SAFE_FUNCTIONS  200809L
+
+#undef  _POSIX_THREAD_ATTR_STACKSIZE
+#define _POSIX_THREAD_ATTR_STACKSIZE  200809L
+
+#undef  _POSIX_ROBUST_MUTEXES
+#define _POSIX_ROBUST_MUTEXES  200809L
+
+/*
+ * The following options are not supported
+ */
+#undef  _POSIX_THREAD_ATTR_STACKADDR
+#define _POSIX_THREAD_ATTR_STACKADDR  -1
+
+#undef  _POSIX_THREAD_PRIO_INHERIT
+#define _POSIX_THREAD_PRIO_INHERIT  -1
+
+#undef  _POSIX_THREAD_PRIO_PROTECT
+#define _POSIX_THREAD_PRIO_PROTECT  -1
+
+/* TPS is not fully supported.  */
+#undef  _POSIX_THREAD_PRIORITY_SCHEDULING
+#define _POSIX_THREAD_PRIORITY_SCHEDULING  -1
+
+#undef  _POSIX_THREAD_PROCESS_SHARED
+#define _POSIX_THREAD_PROCESS_SHARED  -1
+
+
+/*
+ * POSIX 1003.1-2001 Limits
+ * ===========================
+ *
+ * These limits are normally set in <limits.h>, which is not provided with
+ * pthreads-win32.
+ *
+ * PTHREAD_DESTRUCTOR_ITERATIONS
+ *                      Maximum number of attempts to destroy
+ *                      a thread's thread-specific data on
+ *                      termination (must be at least 4)
+ *
+ * PTHREAD_KEYS_MAX
+ *                      Maximum number of thread-specific data keys
+ *                      available per process (must be at least 128)
+ *
+ * PTHREAD_STACK_MIN
+ *                      Minimum supported stack size for a thread
+ *
+ * PTHREAD_THREADS_MAX
+ *                      Maximum number of threads supported per
+ *                      process (must be at least 64).
+ *
+ * SEM_NSEMS_MAX
+ *                      The maximum number of semaphores a process can have.
+ *                      (must be at least 256)
+ *
+ * SEM_VALUE_MAX
+ *                      The maximum value a semaphore can have.
+ *                      (must be at least 32767)
+ *
+ */
+#undef  _POSIX_THREAD_DESTRUCTOR_ITERATIONS
+#define _POSIX_THREAD_DESTRUCTOR_ITERATIONS     4
+
+#undef  PTHREAD_DESTRUCTOR_ITERATIONS
+#define PTHREAD_DESTRUCTOR_ITERATIONS           _POSIX_THREAD_DESTRUCTOR_ITERATIONS
+
+#undef  _POSIX_THREAD_KEYS_MAX
+#define _POSIX_THREAD_KEYS_MAX                  128
+
+#undef  PTHREAD_KEYS_MAX
+#define PTHREAD_KEYS_MAX                        _POSIX_THREAD_KEYS_MAX
+
+#undef  PTHREAD_STACK_MIN
+#define PTHREAD_STACK_MIN                       0
+
+#undef  _POSIX_THREAD_THREADS_MAX
+#define _POSIX_THREAD_THREADS_MAX               64
+
+/* Arbitrary value */
+#undef  PTHREAD_THREADS_MAX
+#define PTHREAD_THREADS_MAX                     2019
+
+#undef  _POSIX_SEM_NSEMS_MAX
+#define _POSIX_SEM_NSEMS_MAX                    256
+
+/* Arbitrary value */
+#undef  SEM_NSEMS_MAX
+#define SEM_NSEMS_MAX                           1024
+
+#undef  _POSIX_SEM_VALUE_MAX
+#define _POSIX_SEM_VALUE_MAX                    32767
+
+#undef  SEM_VALUE_MAX
+#define SEM_VALUE_MAX                           INT_MAX
+
+
+#if defined(_UWIN) && PTW32_LEVEL >= PTW32_LEVEL_MAX
+#   include     <sys/types.h>
+#else
+/* Generic handle type - intended to provide the lifetime-uniqueness that
+ * a simple pointer can't. It should scale for either
+ * 32 or 64 bit systems.
+ *
+ * The constraint with this approach is that applications must
+ * strictly comply with POSIX, e.g. not assume scalar type, only
+ * compare pthread_t using the API function pthread_equal(), etc.
+ *
+ * Non-conforming applications could use the element 'p' to compare,
+ * e.g. for sorting, but it will be up to the application to determine
+ * if handles are live or dead, or resurrected for an entirely
+ * new/different thread. I.e. the thread is valid iff
+ * x == p->ptHandle.x
+ */
+typedef struct 
+{
+  void * p;                   /* Pointer to actual object */
+  size_t x;                   /* Extra information - reuse count etc */
+} ptw32_handle_t;
+
+typedef ptw32_handle_t pthread_t;
+typedef struct pthread_attr_t_ * pthread_attr_t;
+typedef struct pthread_once_t_ pthread_once_t;
+typedef struct pthread_key_t_ * pthread_key_t;
+typedef struct pthread_mutex_t_ * pthread_mutex_t;
+typedef struct pthread_mutexattr_t_ * pthread_mutexattr_t;
+typedef struct pthread_cond_t_ * pthread_cond_t;
+typedef struct pthread_condattr_t_ * pthread_condattr_t;
+#endif
+
+typedef struct pthread_rwlock_t_ * pthread_rwlock_t;
+typedef struct pthread_rwlockattr_t_ * pthread_rwlockattr_t;
+typedef struct pthread_spinlock_t_ * pthread_spinlock_t;
+typedef struct pthread_barrier_t_ * pthread_barrier_t;
+typedef struct pthread_barrierattr_t_ * pthread_barrierattr_t;
+
+/*
+ * ====================
+ * ====================
+ * POSIX Threads
+ * ====================
+ * ====================
+ */
+
+enum 
+{
+  /*
+   * pthread_attr_{get,set}detachstate
+   */
+  PTHREAD_CREATE_JOINABLE       = 0,  /* Default */
+  PTHREAD_CREATE_DETACHED       = 1,
+  /*
+   * pthread_attr_{get,set}inheritsched
+   */
+  PTHREAD_INHERIT_SCHED         = 0,
+  PTHREAD_EXPLICIT_SCHED        = 1,  /* Default */
+  /*
+   * pthread_{get,set}scope
+   */
+  PTHREAD_SCOPE_PROCESS         = 0,
+  PTHREAD_SCOPE_SYSTEM          = 1,  /* Default */
+  /*
+   * pthread_setcancelstate paramters
+   */
+  PTHREAD_CANCEL_ENABLE         = 0,  /* Default */
+  PTHREAD_CANCEL_DISABLE        = 1,
+  /*
+   * pthread_setcanceltype parameters
+   */
+  PTHREAD_CANCEL_ASYNCHRONOUS   = 0,
+  PTHREAD_CANCEL_DEFERRED       = 1,  /* Default */
+  /*
+   * pthread_mutexattr_{get,set}pshared
+   * pthread_condattr_{get,set}pshared
+   */
+  PTHREAD_PROCESS_PRIVATE       = 0,
+  PTHREAD_PROCESS_SHARED        = 1,
+  /*
+   * pthread_mutexattr_{get,set}robust
+   */
+  PTHREAD_MUTEX_STALLED         = 0,  /* Default */
+  PTHREAD_MUTEX_ROBUST          = 1,
+  /*
+   * pthread_barrier_wait
+   */
+  PTHREAD_BARRIER_SERIAL_THREAD = -1
+};
+
+/*
+ * ====================
+ * ====================
+ * Cancellation
+ * ====================
+ * ====================
+ */
+#define PTHREAD_CANCELED       ((void *)(size_t) -1)
+
+
+/*
+ * ====================
+ * ====================
+ * Once Key
+ * ====================
+ * ====================
+ */
+#if  PTW32_VERSION_MAJOR > 2
+
+#define PTHREAD_ONCE_INIT       { 0,  PTW32_FALSE }
+
+struct pthread_once_t_
+{
+  void *       lock;		/* MCS lock */
+  int          done;    	/* indicates if user function has been executed */
+};
+
+#else
+
+#define PTHREAD_ONCE_INIT       { PTW32_FALSE, 0 }
+
+struct pthread_once_t_
+{
+  int          done;       	/* indicates if user function has been executed */
+  void *       lock;		/* MCS lock */
+};
+
+#endif
+
+
+/*
+ * ====================
+ * ====================
+ * Object initialisers
+ * ====================
+ * ====================
+ */
+#define PTHREAD_MUTEX_INITIALIZER ((pthread_mutex_t)(size_t) -1)
+#define PTHREAD_RECURSIVE_MUTEX_INITIALIZER ((pthread_mutex_t)(size_t) -2)
+#define PTHREAD_ERRORCHECK_MUTEX_INITIALIZER ((pthread_mutex_t)(size_t) -3)
+
+/*
+ * Compatibility with LinuxThreads
+ */
+#define PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP PTHREAD_RECURSIVE_MUTEX_INITIALIZER
+#define PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP PTHREAD_ERRORCHECK_MUTEX_INITIALIZER
+
+#define PTHREAD_COND_INITIALIZER ((pthread_cond_t)(size_t) -1)
+
+#define PTHREAD_RWLOCK_INITIALIZER ((pthread_rwlock_t)(size_t) -1)
+
+#define PTHREAD_SPINLOCK_INITIALIZER ((pthread_spinlock_t)(size_t) -1)
+
+
+/*
+ * Mutex types.
+ */
+enum
+{
+  /* Compatibility with LinuxThreads */
+  PTHREAD_MUTEX_FAST_NP,
+  PTHREAD_MUTEX_RECURSIVE_NP,
+  PTHREAD_MUTEX_ERRORCHECK_NP,
+  PTHREAD_MUTEX_TIMED_NP = PTHREAD_MUTEX_FAST_NP,
+  PTHREAD_MUTEX_ADAPTIVE_NP = PTHREAD_MUTEX_FAST_NP,
+  /* For compatibility with POSIX */
+  PTHREAD_MUTEX_NORMAL = PTHREAD_MUTEX_FAST_NP,
+  PTHREAD_MUTEX_RECURSIVE = PTHREAD_MUTEX_RECURSIVE_NP,
+  PTHREAD_MUTEX_ERRORCHECK = PTHREAD_MUTEX_ERRORCHECK_NP,
+  PTHREAD_MUTEX_DEFAULT = PTHREAD_MUTEX_NORMAL
+};
+
+
+typedef struct ptw32_cleanup_t ptw32_cleanup_t;
+
+#if defined(_MSC_VER)
+/* Disable MSVC 'anachronism used' warning */
+#pragma warning( push )
+#pragma warning( disable : 4229 )
+#endif
+
+typedef void (* PTW32_CDECL ptw32_cleanup_callback_t)(void *);
+
+#if defined(_MSC_VER)
+#pragma warning( pop )
+#endif
+
+struct ptw32_cleanup_t
+{
+  ptw32_cleanup_callback_t routine;
+  void *arg;
+  struct ptw32_cleanup_t *prev;
+};
+
+#if defined(PTW32_CLEANUP_SEH)
+        /*
+         * WIN32 SEH version of cancel cleanup.
+         */
+
+#define pthread_cleanup_push( _rout, _arg ) \
+        { \
+            ptw32_cleanup_t     _cleanup; \
+            \
+        _cleanup.routine        = (ptw32_cleanup_callback_t)(_rout); \
+            _cleanup.arg        = (_arg); \
+            __try \
+              { \
+
+#define pthread_cleanup_pop( _execute ) \
+              } \
+            __finally \
+                { \
+                    if( _execute || AbnormalTermination()) \
+                      { \
+                          (*(_cleanup.routine))( _cleanup.arg ); \
+                      } \
+                } \
+        }
+
+#else /* PTW32_CLEANUP_SEH */
+
+#if defined(PTW32_CLEANUP_C)
+
+        /*
+         * C implementation of PThreads cancel cleanup
+         */
+
+#define pthread_cleanup_push( _rout, _arg ) \
+        { \
+            ptw32_cleanup_t     _cleanup; \
+            \
+            ptw32_push_cleanup( &_cleanup, (ptw32_cleanup_callback_t) (_rout), (_arg) ); \
+
+#define pthread_cleanup_pop( _execute ) \
+            (void) ptw32_pop_cleanup( _execute ); \
+        }
+
+#else /* PTW32_CLEANUP_C */
+
+#if defined(PTW32_CLEANUP_CXX)
+
+        /*
+         * C++ version of cancel cleanup.
+         * - John E. Bossom.
+         */
+
+        class PThreadCleanup {
+          /*
+           * PThreadCleanup
+           *
+           * Purpose
+           *      This class is a C++ helper class that is
+           *      used to implement pthread_cleanup_push/
+           *      pthread_cleanup_pop.
+           *      The destructor of this class automatically
+           *      pops the pushed cleanup routine regardless
+           *      of how the code exits the scope
+           *      (i.e. such as by an exception)
+           */
+      ptw32_cleanup_callback_t cleanUpRout;
+          void    *       obj;
+          int             executeIt;
+
+        public:
+          PThreadCleanup() :
+            cleanUpRout( 0 ),
+            obj( 0 ),
+            executeIt( 0 )
+            /*
+             * No cleanup performed
+             */
+            {
+            }
+
+          PThreadCleanup(
+             ptw32_cleanup_callback_t routine,
+                         void    *       arg ) :
+            cleanUpRout( routine ),
+            obj( arg ),
+            executeIt( 1 )
+            /*
+             * Registers a cleanup routine for 'arg'
+             */
+            {
+            }
+
+          ~PThreadCleanup()
+            {
+              if ( executeIt && ((void *) cleanUpRout != (void *) 0) )
+                {
+                  (void) (*cleanUpRout)( obj );
+                }
+            }
+
+          void execute( int exec )
+            {
+              executeIt = exec;
+            }
+        };
+
+        /*
+         * C++ implementation of PThreads cancel cleanup;
+         * This implementation takes advantage of a helper
+         * class who's destructor automatically calls the
+         * cleanup routine if we exit our scope weirdly
+         */
+#define pthread_cleanup_push( _rout, _arg ) \
+        { \
+            PThreadCleanup  cleanup((ptw32_cleanup_callback_t)(_rout), \
+                                    (void *) (_arg) );
+
+#define pthread_cleanup_pop( _execute ) \
+            cleanup.execute( _execute ); \
+        }
+
+#else
+
+#error ERROR [__FILE__, line __LINE__]: Cleanup type undefined.
+
+#endif /* PTW32_CLEANUP_CXX */
+
+#endif /* PTW32_CLEANUP_C */
+
+#endif /* PTW32_CLEANUP_SEH */
+
+
+/*
+ * ===============
+ * ===============
+ * Methods
+ * ===============
+ * ===============
+ */
+
+PTW32_BEGIN_C_DECLS
+
+/*
+ * PThread Attribute Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_init (pthread_attr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_destroy (pthread_attr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getaffinity_np (const pthread_attr_t * attr,
+                                         size_t cpusetsize,
+                                         cpu_set_t * cpuset);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getdetachstate (const pthread_attr_t * attr,
+                                         int *detachstate);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getstackaddr (const pthread_attr_t * attr,
+                                       void **stackaddr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getstacksize (const pthread_attr_t * attr,
+                                       size_t * stacksize);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setaffinity_np (pthread_attr_t * attr,
+                                       size_t cpusetsize,
+                                       const cpu_set_t * cpuset);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setdetachstate (pthread_attr_t * attr,
+                                         int detachstate);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setstackaddr (pthread_attr_t * attr,
+                                       void *stackaddr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setstacksize (pthread_attr_t * attr,
+                                       size_t stacksize);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getschedparam (const pthread_attr_t *attr,
+                                        struct sched_param *param);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setschedparam (pthread_attr_t *attr,
+                                        const struct sched_param *param);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setschedpolicy (pthread_attr_t *,
+                                         int);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getschedpolicy (const pthread_attr_t *,
+                                         int *);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setinheritsched(pthread_attr_t * attr,
+                                         int inheritsched);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getinheritsched(const pthread_attr_t * attr,
+                                         int * inheritsched);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setscope (pthread_attr_t *,
+                                   int);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getscope (const pthread_attr_t *,
+                                   int *);
+
+/*
+ * PThread Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_create (pthread_t * tid,
+                            const pthread_attr_t * attr,
+                            void * (PTW32_CDECL *start) (void *),
+                            void *arg);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_detach (pthread_t tid);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_equal (pthread_t t1,
+                           pthread_t t2);
+
+PTW32_DLLPORT void PTW32_CDECL pthread_exit (void *value_ptr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_join (pthread_t thread,
+                          void **value_ptr);
+
+PTW32_DLLPORT pthread_t PTW32_CDECL pthread_self (void);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_cancel (pthread_t thread);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_setcancelstate (int state,
+                                    int *oldstate);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_setcanceltype (int type,
+                                   int *oldtype);
+
+PTW32_DLLPORT void PTW32_CDECL pthread_testcancel (void);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_once (pthread_once_t * once_control,
+                          void  (PTW32_CDECL *init_routine) (void));
+
+#if PTW32_LEVEL >= PTW32_LEVEL_MAX
+PTW32_DLLPORT ptw32_cleanup_t * PTW32_CDECL ptw32_pop_cleanup (int execute);
+
+PTW32_DLLPORT void PTW32_CDECL ptw32_push_cleanup (ptw32_cleanup_t * cleanup,
+                                 ptw32_cleanup_callback_t routine,
+                                 void *arg);
+#endif /* PTW32_LEVEL >= PTW32_LEVEL_MAX */
+
+/*
+ * Thread Specific Data Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_key_create (pthread_key_t * key,
+                                void (PTW32_CDECL *destructor) (void *));
+
+PTW32_DLLPORT int PTW32_CDECL pthread_key_delete (pthread_key_t key);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_setspecific (pthread_key_t key,
+                                 const void *value);
+
+PTW32_DLLPORT void * PTW32_CDECL pthread_getspecific (pthread_key_t key);
+
+
+/*
+ * Mutex Attribute Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_init (pthread_mutexattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_destroy (pthread_mutexattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_getpshared (const pthread_mutexattr_t
+                                          * attr,
+                                          int *pshared);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_setpshared (pthread_mutexattr_t * attr,
+                                          int pshared);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_settype (pthread_mutexattr_t * attr, int kind);
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_gettype (const pthread_mutexattr_t * attr, int *kind);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_setrobust(
+                                           pthread_mutexattr_t *attr,
+                                           int robust);
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_getrobust(
+                                           const pthread_mutexattr_t * attr,
+                                           int * robust);
+
+/*
+ * Barrier Attribute Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_barrierattr_init (pthread_barrierattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_barrierattr_destroy (pthread_barrierattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_barrierattr_getpshared (const pthread_barrierattr_t
+                                            * attr,
+                                            int *pshared);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_barrierattr_setpshared (pthread_barrierattr_t * attr,
+                                            int pshared);
+
+/*
+ * Mutex Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_mutex_init (pthread_mutex_t * mutex,
+                                const pthread_mutexattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutex_destroy (pthread_mutex_t * mutex);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutex_lock (pthread_mutex_t * mutex);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutex_timedlock(pthread_mutex_t * mutex,
+                                    const struct timespec *abstime);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutex_trylock (pthread_mutex_t * mutex);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutex_unlock (pthread_mutex_t * mutex);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_mutex_consistent (pthread_mutex_t * mutex);
+
+/*
+ * Spinlock Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_spin_init (pthread_spinlock_t * lock, int pshared);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_spin_destroy (pthread_spinlock_t * lock);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_spin_lock (pthread_spinlock_t * lock);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_spin_trylock (pthread_spinlock_t * lock);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_spin_unlock (pthread_spinlock_t * lock);
+
+/*
+ * Barrier Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_barrier_init (pthread_barrier_t * barrier,
+                                  const pthread_barrierattr_t * attr,
+                                  unsigned int count);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_barrier_destroy (pthread_barrier_t * barrier);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_barrier_wait (pthread_barrier_t * barrier);
+
+/*
+ * Condition Variable Attribute Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_condattr_init (pthread_condattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_condattr_destroy (pthread_condattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_condattr_getpshared (const pthread_condattr_t * attr,
+                                         int *pshared);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_condattr_setpshared (pthread_condattr_t * attr,
+                                         int pshared);
+
+/*
+ * Condition Variable Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_cond_init (pthread_cond_t * cond,
+                               const pthread_condattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_cond_destroy (pthread_cond_t * cond);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_cond_wait (pthread_cond_t * cond,
+                               pthread_mutex_t * mutex);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_cond_timedwait (pthread_cond_t * cond,
+                                    pthread_mutex_t * mutex,
+                                    const struct timespec *abstime);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_cond_signal (pthread_cond_t * cond);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_cond_broadcast (pthread_cond_t * cond);
+
+/*
+ * Scheduling
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_setschedparam (pthread_t thread,
+                                   int policy,
+                                   const struct sched_param *param);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_getschedparam (pthread_t thread,
+                                   int *policy,
+                                   struct sched_param *param);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_setconcurrency (int);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_getconcurrency (void);
+
+/*
+ * Read-Write Lock Functions
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_init(pthread_rwlock_t *lock,
+                                const pthread_rwlockattr_t *attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_destroy(pthread_rwlock_t *lock);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_tryrdlock(pthread_rwlock_t *);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_trywrlock(pthread_rwlock_t *);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_rdlock(pthread_rwlock_t *lock);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_timedrdlock(pthread_rwlock_t *lock,
+                                       const struct timespec *abstime);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_wrlock(pthread_rwlock_t *lock);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_timedwrlock(pthread_rwlock_t *lock,
+                                       const struct timespec *abstime);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlock_unlock(pthread_rwlock_t *lock);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlockattr_init (pthread_rwlockattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlockattr_destroy (pthread_rwlockattr_t * attr);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlockattr_getpshared (const pthread_rwlockattr_t * attr,
+                                           int *pshared);
+
+PTW32_DLLPORT int PTW32_CDECL pthread_rwlockattr_setpshared (pthread_rwlockattr_t * attr,
+                                           int pshared);
+
+#if PTW32_LEVEL >= PTW32_LEVEL_MAX - 1
+
+/*
+ * Signal Functions. Should be defined in <signal.h> but MSVC and MinGW32
+ * already have signal.h that don't define these.
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_kill(pthread_t thread, int sig);
+
+/*
+ * Non-portable functions
+ */
+
+/*
+ * Compatibility with Linux.
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_setkind_np(pthread_mutexattr_t * attr,
+                                         int kind);
+PTW32_DLLPORT int PTW32_CDECL pthread_mutexattr_getkind_np(pthread_mutexattr_t * attr,
+                                         int *kind);
+PTW32_DLLPORT int PTW32_CDECL pthread_timedjoin_np(pthread_t thread,
+                                         void **value_ptr,
+                                         const struct timespec *abstime);
+PTW32_DLLPORT int PTW32_CDECL pthread_tryjoin_np(pthread_t thread,
+                                         void **value_ptr);
+PTW32_DLLPORT int PTW32_CDECL pthread_setaffinity_np(pthread_t thread,
+										 size_t cpusetsize,
+										 const cpu_set_t *cpuset);
+PTW32_DLLPORT int PTW32_CDECL pthread_getaffinity_np(pthread_t thread,
+										 size_t cpusetsize,
+										 cpu_set_t *cpuset);
+
+/*
+ * Possibly supported by other POSIX threads implementations
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_delay_np (struct timespec * interval);
+PTW32_DLLPORT int PTW32_CDECL pthread_num_processors_np(void);
+PTW32_DLLPORT unsigned __int64 PTW32_CDECL pthread_getunique_np(pthread_t thread);
+
+/*
+ * Useful if an application wants to statically link
+ * the lib rather than load the DLL at run-time.
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_win32_process_attach_np(void);
+PTW32_DLLPORT int PTW32_CDECL pthread_win32_process_detach_np(void);
+PTW32_DLLPORT int PTW32_CDECL pthread_win32_thread_attach_np(void);
+PTW32_DLLPORT int PTW32_CDECL pthread_win32_thread_detach_np(void);
+
+/*
+ * Returns the first parameter "abstime" modified to represent the current system time.
+ * If "relative" is not NULL it represents an interval to add to "abstime".
+ */
+
+PTW32_DLLPORT struct timespec * PTW32_CDECL pthread_win32_getabstime_np(
+						      struct timespec * abstime,
+						      const struct timespec * relative);
+
+/*
+ * Features that are auto-detected at load/run time.
+ */
+PTW32_DLLPORT int PTW32_CDECL pthread_win32_test_features_np(int);
+enum ptw32_features 
+{
+  PTW32_SYSTEM_INTERLOCKED_COMPARE_EXCHANGE = 0x0001,	/* System provides it. */
+  PTW32_ALERTABLE_ASYNC_CANCEL              = 0x0002	/* Can cancel blocked threads. */
+};
+
+/*
+ * Register a system time change with the library.
+ * Causes the library to perform various functions
+ * in response to the change. Should be called whenever
+ * the application's top level window receives a
+ * WM_TIMECHANGE message. It can be passed directly to
+ * pthread_create() as a new thread if desired.
+ */
+PTW32_DLLPORT void * PTW32_CDECL pthread_timechange_handler_np(void *);
+
+#endif /* PTW32_LEVEL >= PTW32_LEVEL_MAX - 1 */
+
+#if PTW32_LEVEL >= PTW32_LEVEL_MAX
+
+/*
+ * Returns the Win32 HANDLE for the POSIX thread.
+ */
+PTW32_DLLPORT void * PTW32_CDECL pthread_getw32threadhandle_np(pthread_t thread);
+/*
+ * Returns the win32 thread ID for POSIX thread.
+ */
+PTW32_DLLPORT unsigned long PTW32_CDECL pthread_getw32threadid_np (pthread_t thread);
+
+/*
+ * Sets the POSIX thread name. If _MSC_VER is defined the name should be displayed by
+ * the MSVS debugger.
+ */
+#if defined(PTW32_COMPATIBILITY_BSD) || defined(PTW32_COMPATIBILITY_TRU64)
+#define PTHREAD_MAX_NAMELEN_NP 16
+PTW32_DLLPORT int PTW32_CDECL pthread_setname_np (pthread_t thr, const char * name, void * arg);
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setname_np (pthread_attr_t * attr, const char * name, void * arg);
+#else
+PTW32_DLLPORT int PTW32_CDECL pthread_setname_np (pthread_t thr, const char * name);
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_setname_np (pthread_attr_t * attr, const char * name);
+#endif
+
+PTW32_DLLPORT int PTW32_CDECL pthread_getname_np (pthread_t thr, char * name, int len);
+PTW32_DLLPORT int PTW32_CDECL pthread_attr_getname_np (pthread_attr_t * attr, char * name, int len);
+
+
+/*
+ * Protected Methods
+ *
+ * This function blocks until the given WIN32 handle
+ * is signalled or pthread_cancel had been called.
+ * This function allows the caller to hook into the
+ * PThreads cancel mechanism. It is implemented using
+ *
+ *              WaitForMultipleObjects
+ *
+ * on 'waitHandle' and a manually reset WIN32 Event
+ * used to implement pthread_cancel. The 'timeout'
+ * argument to TimedWait is simply passed to
+ * WaitForMultipleObjects.
+ */
+PTW32_DLLPORT int  PTW32_CDECL pthreadCancelableWait (void *waitHandle);
+PTW32_DLLPORT int  PTW32_CDECL pthreadCancelableTimedWait (void *waitHandle,
+                                        unsigned long timeout);
+
+#endif /* PTW32_LEVEL >= PTW32_LEVEL_MAX */
+
+/*
+ * Declare a thread-safe errno for Open Watcom
+ * (note: this has not been tested in a long time)
+ */
+#if defined(__WATCOMC__) && !defined(errno)
+#  if defined(_MT) || defined(_DLL)
+     __declspec(dllimport) extern int * __cdecl _errno(void);
+#    define errno (*_errno())
+#  endif
+#endif
+
+#if defined (PTW32_USES_SEPARATE_CRT) && (defined(PTW32_CLEANUP_CXX) || defined(PTW32_CLEANUP_SEH))
+typedef void (*ptw32_terminate_handler)();
+PTW32_DLLPORT ptw32_terminate_handler PTW32_CDECL pthread_win32_set_terminate_np(ptw32_terminate_handler termFunction);
+#endif
+
+#if defined(__cplusplus)
+
+/*
+ * Internal exceptions
+ */
+class ptw32_exception {};
+class ptw32_exception_cancel : public ptw32_exception {};
+class ptw32_exception_exit   : public ptw32_exception {};
+
+#endif
+
+#if PTW32_LEVEL >= PTW32_LEVEL_MAX
+
+/* FIXME: This is only required if the library was built using SEH */
+/*
+ * Get internal SEH tag
+ */
+PTW32_DLLPORT unsigned long  PTW32_CDECL ptw32_get_exception_services_code(void);
+
+#endif /* PTW32_LEVEL >= PTW32_LEVEL_MAX */
+
+#if !defined(PTW32_BUILD)
+
+#if defined(PTW32_CLEANUP_SEH)
+
+/*
+ * Redefine the SEH __except keyword to ensure that applications
+ * propagate our internal exceptions up to the library's internal handlers.
+ */
+#define __except( E ) \
+        __except( ( GetExceptionCode() == ptw32_get_exception_services_code() ) \
+                 ? EXCEPTION_CONTINUE_SEARCH : ( E ) )
+
+#endif /* PTW32_CLEANUP_SEH */
+
+#if defined(PTW32_CLEANUP_CXX)
+
+/*
+ * Redefine the C++ catch keyword to ensure that applications
+ * propagate our internal exceptions up to the library's internal handlers.
+ */
+#if defined(_MSC_VER)
+        /*
+         * WARNING: Replace any 'catch( ... )' with '__PtW32CatchAll'
+         * if you want Pthread-Win32 cancellation and pthread_exit to work.
+         */
+
+#if !defined(__PtW32NoCatchWarn)
+
+#pragma message("Specify \"/D__PtW32NoCatchWarn\" compiler flag to skip this message.")
+#pragma message("------------------------------------------------------------------")
+#pragma message("When compiling applications with MSVC++ and C++ exception handling:")
+#pragma message("  Replace any 'catch( ... )' in routines called from POSIX threads")
+#pragma message("  with '__PtW32CatchAll' or 'CATCHALL' if you want POSIX thread")
+#pragma message("  cancellation and pthread_exit to work. For example:")
+#pragma message("")
+#pragma message("    #if defined(__PtW32CatchAll)")
+#pragma message("      __PtW32CatchAll")
+#pragma message("    #else")
+#pragma message("      catch(...)")
+#pragma message("    #endif")
+#pragma message("        {")
+#pragma message("          /* Catchall block processing */")
+#pragma message("        }")
+#pragma message("------------------------------------------------------------------")
+
+#endif
+
+#define __PtW32CatchAll \
+        catch( ptw32_exception & ) { throw; } \
+        catch( ... )
+
+#else /* _MSC_VER */
+
+#define catch( E ) \
+        catch( ptw32_exception & ) { throw; } \
+        catch( E )
+
+#endif /* _MSC_VER */
+
+#endif /* PTW32_CLEANUP_CXX */
+
+#endif /* ! PTW32_BUILD */
+
+PTW32_END_C_DECLS
+
+#undef PTW32_LEVEL
+#undef PTW32_LEVEL_MAX
+
+#endif /* ! RC_INVOKED */
+
+#endif /* PTHREAD_H */

--- a/pthread/include/sched.h
+++ b/pthread/include/sched.h
@@ -1,0 +1,246 @@
+/*
+ * Module: sched.h
+ *
+ * Purpose:
+ *      Provides an implementation of POSIX realtime extensions
+ *      as defined in
+ *
+ *              POSIX 1003.1b-1993      (POSIX.1b)
+ *
+ * --------------------------------------------------------------------------
+ *
+ *      pthreads-win32 - POSIX Threads Library for Win32
+ *      Copyright(C) 1998 John E. Bossom
+ *      Copyright(C) 1999-2021 pthreads-win32 / pthreads4w contributors
+ *
+ *      Homepage1: http://sourceware.org/pthreads-win32/
+ *      Homepage2: http://sourceforge.net/projects/pthreads4w/
+ *
+ *      The current list of contributors is contained
+ *      in the file CONTRIBUTORS included with the source
+ *      code distribution. The list can also be seen at the
+ *      following World Wide Web location:
+ *      http://sources.redhat.com/pthreads-win32/contributors.html
+ * 
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2 of the License, or (at your option) any later version.
+ * 
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ * 
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library in the file COPYING.LIB;
+ *      if not, write to the Free Software Foundation, Inc.,
+ *      59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+ *
+ * --------------------------------------------------------------------------
+ */
+#pragma once
+#if !defined(_SCHED_H)
+#define _SCHED_H
+#define __SCHED_H_SOURCED__
+
+#include <_ptw32.h>
+
+/* We need a typedef for pid_t, (and POSIX requires <sched.h> to
+ * define it, as it is defined in <sys/types.h>, but it does NOT
+ * sanction exposure of everything from <sys/types.h>); there is
+ * no pid_t in Windows anyway, (except that MinGW does define it
+ * in their <sys/types.h>), so just provide a suitable typedef,
+ * but note that we must do so cautiously, to avoid a typedef
+ * conflict if MinGW's <sys/types.h> is also #included:
+ */
+#if ! defined __MINGW32__ || ! defined __have_typedef_pid_t
+
+# if defined __MINGW64__
+    typedef __int64 pid_t;
+# else
+    typedef int pid_t;
+#endif
+
+#if __GNUC__ < 4
+/* GCC v4.0 and later, (as used by MinGW), allows us to repeat a
+ * typedef, provided every duplicate is consistent; only set this
+ * multiple definition guard when we cannot be certain that it is
+ * permissable to repeat typedefs.
+ */
+#define __have_typedef_pid_t  1
+#endif
+#endif
+
+/* POSIX.1-1993 says that <sched.h> WILL expose all of <time.h>
+ */
+#undef __SCHED_H_SOURCED__
+#if _POSIX_C_SOURCE >= 200112L
+/* POSIX.1-2001 and later revises this to say only that it MAY do so;
+ * only struct timespec, and associated time_t are actually required,
+ * so prefer to be selective; (MinGW.org's <time.h> offers an option
+ * for selective #inclusion, when __SCHED_H_SOURCED__ is defined):
+ */
+#define __SCHED_H_SOURCED__
+#define __need_struct_timespec
+#define __need_time_t
+#endif
+#include <time.h>
+
+#if defined __MINGW64__ || _MSC_VER >= 1900
+/* These are known to define struct timespec, when <time.h> has been
+ * #included, but may not, (probably don't), follow the convention of
+ * defining __struct_timespec_defined, as adopted by MinGW.org; for
+ * these cases, we unconditionally assume that struct timespec has
+ * been defined, otherwise, if MinGW.org's criterion has not been
+ * satisfied...
+ */
+#elif ! defined __struct_timespec_defined
+#  ifndef _TIMESPEC_DEFINED
+#  define _TIMESPEC_DEFINED
+struct timespec
+{ /* ...we fall back on this explicit definition.
+   */
+  time_t	tv_sec;
+  int		tv_nsec;
+};
+#  endif
+#endif
+
+/*
+ * Microsoft VC++6.0 lacks these *_PTR types
+ */
+#if defined(_MSC_VER) && _MSC_VER < 1300 && !defined(PTW32_HAVE_DWORD_PTR)
+typedef unsigned long ULONG_PTR;
+typedef ULONG_PTR DWORD_PTR;
+#endif
+
+/* Thread scheduling policies */
+
+enum
+{ 
+  SCHED_OTHER = 0,
+  SCHED_FIFO,
+  SCHED_RR,
+  SCHED_MIN   = SCHED_OTHER,
+  SCHED_MAX   = SCHED_RR
+};
+
+struct sched_param
+{ 
+  int  sched_priority;
+};
+
+/*
+ * CPU affinity
+ *
+ * cpu_set_t:
+ * Considered opaque but cannot be an opaque pointer due to the need for
+ * compatibility with GNU systems and sched_setaffinity() et.al., which
+ * include the cpusetsize parameter "normally set to sizeof(cpu_set_t)".
+ *
+ * FIXME: These are GNU, and NOT specified by POSIX; maybe consider
+ * occluding them within a _GNU_SOURCE (or similar) feature test.
+ */
+
+#define CPU_SETSIZE (sizeof(size_t)*8)
+
+#define CPU_COUNT(setptr) (_sched_affinitycpucount(setptr))
+
+#define CPU_ZERO(setptr) (_sched_affinitycpuzero(setptr))
+
+#define CPU_SET(cpu, setptr) (_sched_affinitycpuset((cpu),(setptr)))
+
+#define CPU_CLR(cpu, setptr) (_sched_affinitycpuclr((cpu),(setptr)))
+
+#define CPU_ISSET(cpu, setptr) (_sched_affinitycpuisset((cpu),(setptr)))
+
+#define CPU_AND(destsetptr, srcset1ptr, srcset2ptr) (_sched_affinitycpuand((destsetptr),(srcset1ptr),(srcset2ptr)))
+
+#define CPU_OR(destsetptr, srcset1ptr, srcset2ptr) (_sched_affinitycpuor((destsetptr),(srcset1ptr),(srcset2ptr)))
+
+#define CPU_XOR(destsetptr, srcset1ptr, srcset2ptr) \
+ (_sched_affinitycpuxor((destsetptr),(srcset1ptr),(srcset2ptr)))
+
+#define CPU_EQUAL(set1ptr, set2ptr) (_sched_affinitycpuequal((set1ptr),(set2ptr)))
+
+typedef union
+{ 
+  char     cpuset[CPU_SETSIZE/8];
+  size_t  _align;
+} cpu_set_t;
+
+PTW32_BEGIN_C_DECLS
+
+PTW32_DLLPORT int PTW32_CDECL sched_yield (void);
+
+PTW32_DLLPORT int PTW32_CDECL sched_get_priority_min (int policy);
+
+PTW32_DLLPORT int PTW32_CDECL sched_get_priority_max (int policy);
+
+/* FIXME: this declaration of sched_setscheduler() is NOT as prescribed
+ * by POSIX; it lacks const struct sched_param * as third argument.
+ */
+PTW32_DLLPORT int PTW32_CDECL sched_setscheduler (pid_t pid, int policy);
+
+PTW32_DLLPORT int PTW32_CDECL sched_getscheduler (pid_t pid);
+
+/* FIXME: In addition to the above five functions, POSIX also requires:
+ *
+ *   int sched_getparam (pid_t, struct sched_param *);
+ *   int sched_setparam (pid_t, const struct sched_param *);
+ *
+ * both of which are conspicuous by their absence here!
+ */
+
+/* Compatibility with Linux - not standard in POSIX
+ * FIXME: consider occluding within a _GNU_SOURCE (or similar) feature test.
+ */
+PTW32_DLLPORT int PTW32_CDECL sched_setaffinity (pid_t pid, size_t cpusetsize, cpu_set_t *mask);
+
+PTW32_DLLPORT int PTW32_CDECL sched_getaffinity (pid_t pid, size_t cpusetsize, cpu_set_t *mask);
+
+/*
+ * Support routines and macros for cpu_set_t
+ */
+PTW32_DLLPORT int PTW32_CDECL _sched_affinitycpucount (const cpu_set_t *set);
+
+PTW32_DLLPORT void PTW32_CDECL _sched_affinitycpuzero (cpu_set_t *pset);
+
+PTW32_DLLPORT void PTW32_CDECL _sched_affinitycpuset (int cpu, cpu_set_t *pset);
+
+PTW32_DLLPORT void PTW32_CDECL _sched_affinitycpuclr (int cpu, cpu_set_t *pset);
+
+PTW32_DLLPORT int PTW32_CDECL _sched_affinitycpuisset (int cpu, const cpu_set_t *pset);
+
+PTW32_DLLPORT void PTW32_CDECL _sched_affinitycpuand(cpu_set_t *pdestset, const cpu_set_t *psrcset1, const cpu_set_t *psrcset2);
+
+PTW32_DLLPORT void PTW32_CDECL _sched_affinitycpuor(cpu_set_t *pdestset, const cpu_set_t *psrcset1, const cpu_set_t *psrcset2);
+
+PTW32_DLLPORT void PTW32_CDECL _sched_affinitycpuxor(cpu_set_t *pdestset, const cpu_set_t *psrcset1, const cpu_set_t *psrcset2);
+
+PTW32_DLLPORT int PTW32_CDECL _sched_affinitycpuequal (const cpu_set_t *pset1, const cpu_set_t *pset2);
+
+/* Note that this macro returns ENOTSUP rather than ENOSYS, as
+ * might be expected. However, returning ENOSYS should mean that
+ * sched_get_priority_{min,max} are not implemented as well as
+ * sched_rr_get_interval.  This is not the case, since we just
+ * don't support round-robin scheduling. Therefore I have chosen
+ * to return the same value as sched_setscheduler when SCHED_RR
+ * is passed to it.
+ *
+ * FIXME: POSIX requires this to be defined as a function; this
+ * macro implementation is permitted IN ADDITION to the function,
+ * but the macro alone is not POSIX compliant!  Worse still, it
+ * imposes a requirement on the caller, to ensure that both the
+ * declaration of errno, and the definition of ENOTSUP, are in
+ * scope at point of call, (which it may wish to do anyway, but
+ * POSIX imposes no such constraint)!
+ */
+#define sched_rr_get_interval(_pid, _interval) \
+  ( errno = ENOTSUP, (int) -1 )
+
+PTW32_END_C_DECLS
+
+#undef __SCHED_H_SOURCED__
+#endif	/* !_SCHED_H */

--- a/pthread/include/semaphore.h
+++ b/pthread/include/semaphore.h
@@ -1,0 +1,122 @@
+/*
+ * Module: semaphore.h
+ *
+ * Purpose:
+ *	Semaphores aren't actually part of the PThreads standard.
+ *	They are defined by the POSIX Standard:
+ *
+ *		POSIX 1003.1b-1993	(POSIX.1b)
+ *
+ * --------------------------------------------------------------------------
+ *
+ *      pthreads-win32 - POSIX Threads Library for Win32
+ *      Copyright(C) 1998 John E. Bossom
+ *      Copyright(C) 1999-2021 pthreads-win32 / pthreads4w contributors
+ *
+ *      Homepage1: http://sourceware.org/pthreads-win32/
+ *      Homepage2: http://sourceforge.net/projects/pthreads4w/
+ *
+ *      The current list of contributors is contained
+ *      in the file CONTRIBUTORS included with the source
+ *      code distribution. The list can also be seen at the
+ *      following World Wide Web location:
+ *      http://sources.redhat.com/pthreads-win32/contributors.html
+ * 
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2 of the License, or (at your option) any later version.
+ * 
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ * 
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library in the file COPYING.LIB;
+ *      if not, write to the Free Software Foundation, Inc.,
+ *      59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+ *
+ * --------------------------------------------------------------------------
+ */
+#pragma once
+#if !defined( SEMAPHORE_H )
+#define SEMAPHORE_H
+
+/* FIXME: POSIX.1 says that _POSIX_SEMAPHORES should be defined
+ * in <unistd.h>, not here; for later POSIX.1 versions, its value
+ * should match the corresponding _POSIX_VERSION number, but in
+ * the case of POSIX.1b-1993, the value is unspecified.
+ *
+ * Notwithstanding the above, since POSIX semaphores, (and indeed
+ * having any <unistd.h> to #include), are not a standard feature
+ * on MS-Windows, it is convenient to retain this definition here;
+ * we may consider adding a hook, to make it selectively available
+ * for inclusion by <unistd.h>, in those cases (e.g. MinGW) where
+ * <unistd.h> is provided.
+ */
+#define _POSIX_SEMAPHORES
+
+/* Internal macros, common to the public interfaces for various
+ * pthreads-win32 components, are defined in <_ptw32.h>; we must
+ * include them here.
+ */
+#include "_ptw32.h"
+
+/* The sem_timedwait() function was added in POSIX.1-2001; it
+ * requires struct timespec to be defined, at least as a partial
+ * (a.k.a. incomplete) data type.  Forward declare it as such,
+ * then include <time.h> selectively, to acquire a complete
+ * definition, (if available).
+ */
+struct timespec;
+#define __need_struct_timespec
+#include <time.h>
+
+/* The data type used to represent our semaphore implementation,
+ * as required by POSIX.1; FIXME: consider renaming the underlying
+ * structure tag, to avoid possible pollution of user namespace.
+ */
+typedef struct sem_t_ * sem_t;
+
+/* POSIX.1b (and later) mandates SEM_FAILED as the value to be
+ * returned on failure of sem_open(); (our implementation is a
+ * stub, which will always return this).
+ */
+#define SEM_FAILED  (sem_t *)(intptr_t)(-1)
+
+PTW32_BEGIN_C_DECLS
+
+/* Function prototypes: some are implemented as stubs, which
+ * always fail; (FIXME: identify them).
+ */
+PTW32_DLLPORT int PTW32_CDECL sem_init (sem_t * sem,
+					int pshared,
+					unsigned int value);
+
+PTW32_DLLPORT int PTW32_CDECL sem_destroy (sem_t * sem);
+
+PTW32_DLLPORT int PTW32_CDECL sem_trywait (sem_t * sem);
+
+PTW32_DLLPORT int PTW32_CDECL sem_wait (sem_t * sem);
+
+PTW32_DLLPORT int PTW32_CDECL sem_timedwait (sem_t * sem,
+					     const struct timespec * abstime);
+
+PTW32_DLLPORT int PTW32_CDECL sem_post (sem_t * sem);
+
+PTW32_DLLPORT int PTW32_CDECL sem_post_multiple (sem_t * sem,
+						 int count);
+
+PTW32_DLLPORT sem_t * PTW32_CDECL sem_open (const char * name, int oflag, ...);
+
+PTW32_DLLPORT int PTW32_CDECL sem_close (sem_t * sem);
+
+PTW32_DLLPORT int PTW32_CDECL sem_unlink (const char * name);
+
+PTW32_DLLPORT int PTW32_CDECL sem_getvalue (sem_t * sem,
+					    int * sval);
+
+PTW32_END_C_DECLS
+
+#endif				/* !SEMAPHORE_H */

--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -53,6 +53,8 @@
  *  This allows to keep the IP if the channel comes back
  */
 
+#define _CRT_SECURE_NO_WARNINGS
+
 #ifndef _WIN32
 #include <sys/ioctl.h>
 #include <sys/poll.h>

--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * MuMuDVB - Stream a DVB transport stream.
  * File for Autoconfiguration
  *
@@ -29,11 +29,11 @@
 
 /** @file
  *  @brief This file contain the code related to the autoconfiguration of MuMudvb
- * 
+ *
  *  It contains the functions to extract the relevant informations from the PAT,PMT,SDT PIDs and from ATSC PSIP table
- * 
+ *
  *  The PAT contains the list of the channels in the actual stream, their service number and the PMT PID
- * 
+ *
  *  The SDT contains the name of the channels associated to a certain service number and the type of service
  *
  *  The PSIP (ATSC only) table contains the same kind of information as the SDT
@@ -53,8 +53,11 @@
  *  This allows to keep the IP if the channel comes back
  */
 
-
+#ifndef _WIN32
 #include <sys/ioctl.h>
+#include <sys/poll.h>
+#endif
+
 #include <errno.h>
 #include <stdint.h>
 
@@ -66,7 +69,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <sys/poll.h>
 
 
 #include "errors.h"

--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -56,6 +56,7 @@
 #ifndef _WIN32
 #include <sys/ioctl.h>
 #include <sys/poll.h>
+#include <unistd.h>
 #endif
 
 #include <errno.h>
@@ -65,7 +66,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/src/autoconf_atsc.c
+++ b/src/autoconf_atsc.c
@@ -139,7 +139,7 @@ int autoconf_read_psip(auto_p_t *auto_p, mumu_chan_p_t *chan_p)
 	else
 	{
 		//New version, no section seen
-		for(int i=0;i<256;i++)
+		for(i=0;i<256;i++)
 			auto_p->psip_sections_seen[i]=0;
 		auto_p->psip_version=psip->version_number;
 		auto_p->psip_all_sections_seen=0;
@@ -167,7 +167,7 @@ int autoconf_read_psip(auto_p_t *auto_p, mumu_chan_p_t *chan_p)
 
 	int sections_missing=0;
 	//We check if we saw all sections
-	for(int i=0;i<=psip->last_section_number;i++)
+	for(i=0;i<=psip->last_section_number;i++)
 		if(auto_p->psip_sections_seen[i]==0)
 			sections_missing++;
 	if(sections_missing)

--- a/src/autoconf_pat.c
+++ b/src/autoconf_pat.c
@@ -32,6 +32,7 @@
  *
  */
 
+#define _CRT_SECURE_NO_WARNINGS
 
 #include <errno.h>
 #include <string.h>

--- a/src/autoconf_pmt.c
+++ b/src/autoconf_pmt.c
@@ -135,9 +135,9 @@ void autoconf_get_pmt_pids(auto_p_t *auto_p, mumudvb_ts_packet_t *pmt, int *pids
 			// The pid might be already added (the EMM pid might be used by different CA systems)
 			// Check if it was already added
 			int pid_already_added = 0;
-			for(int i = 0; i < *num_pids; i++)
+			for(int j = 0; j < *num_pids; j++)
 			{
-				if(pids[i] == ca_system->emm_pid)
+				if(pids[j] == ca_system->emm_pid)
 				{
 					pid_already_added = 1;
 					break;
@@ -480,7 +480,8 @@ int autoconf_read_pmt(auto_p_t *auto_p, mumudvb_channel_t *channel, mumudvb_ts_p
 
 		//We display it just for information the filter update is done elsewhere
 		//We search for added PIDs
-		for(int i=0,found=0;i<temp_num_pids;i++)
+		found = 0;
+		for(int i=0;i<temp_num_pids;i++)
 		{
 			for(int j=0;j<channel->pid_i.num_pids;j++)
 				if(channel->pid_i.pids[j]==temp_pids[i])
@@ -492,7 +493,8 @@ int autoconf_read_pmt(auto_p_t *auto_p, mumudvb_channel_t *channel, mumudvb_ts_p
 						temp_pids_language[i]);
 		}
 		//We search for suppressed pids
-		for(int i=0,found=0;i<channel->pid_i.num_pids;i++)
+		found = 0;
+		for(int i=0;i<channel->pid_i.num_pids;i++)
 		{
 			for(int j=0;j<temp_num_pids;j++)
 				if(channel->pid_i.pids[i]==temp_pids[j] || channel->pid_i.pids[i] == channel->pid_i.pmt_pid )

--- a/src/autoconf_sdt.c
+++ b/src/autoconf_sdt.c
@@ -1,27 +1,27 @@
-/* 
+/*
  * MuMuDVB - Stream a DVB transport stream.
  * File for Autoconfiguration
- * 
+ *
  * (C) 2008-2010 Brice DUBOST <mumudvb@braice.net>
- *  
+ *
  * Parts of this code come from libdvb, modified for mumudvb
- * by Brice DUBOST 
+ * by Brice DUBOST
  * Libdvb part : Copyright (C) 2000 Klaus Schmidinger
- * 
+ *
  * The latest version can be found at http://mumudvb.net
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -312,10 +312,3 @@ void parse_service_descriptor(unsigned char *buf, mumudvb_channel_t *chan)
 			encodings_en300468[encoding_control_char]);
 
 }
-
-
-
-
-
-
-

--- a/src/cam.c
+++ b/src/cam.c
@@ -1,7 +1,7 @@
-/* 
+/*
  * MuMuDVB - Stream a DVB transport stream.
  * File for Conditionnal Access Modules support
- * 
+ *
  * (C) 2004-2011 Brice DUBOST <mumudvb@braice.net>
  *
  * The latest version can be found at http://mumudvb.net
@@ -9,19 +9,19 @@
  * Code inspired by libdvben50221 examples from dvb apps
  * Copyright (C) 2004, 2005 Manu Abraham <abraham.manu@gmail.com>
  * Copyright (C) 2006 Andrew de Quincey (adq_dvb@lidskialf.net)
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -47,7 +47,7 @@
 
 /**@file
  * @brief cam support
- * 
+ *
  * Code for talking with conditionnal access modules. This code uses the libdvben50221 from dvb-apps
  */
 
@@ -684,7 +684,7 @@ int mumudvb_cam_new_pmt(cam_p_t *cam_p, mumudvb_ts_packet_t *cam_pmt_ptr, int ne
 		if ((size = en50221_ca_format_pmt(pmt, capmt, sizeof(capmt), cam_p->moveca, list_managment, CA_PMT_CMD_ID_OK_DESCRAMBLING)) < 0) {
 
 			/*CA_PMT_CMD_ID_QUERY)) < 0) {
-	We don't do query, the query is never working very well. This is because the CAM cannot ask the card if 
+	We don't do query, the query is never working very well. This is because the CAM cannot ask the card if
 	you have the rights for the channel. So this answer is often not reliable.
 
 	Much thanks to Aston www.aston-france.com for the explanation

--- a/src/config_win32.h
+++ b/src/config_win32.h
@@ -1,0 +1,186 @@
+/* src/config.h.  Generated from config.h.in by configure.  */
+/* src/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if you want build for android */
+/* #undef ANDROID */
+
+/* Define if you want to bulid without DVB API */
+#define DISABLE_DVB_API 1
+
+/* Define if you want the CAM support */
+/* #undef ENABLE_CAM_SUPPORT */
+
+/* Define if you want the SCAM support */
+/* #undef ENABLE_SCAM_SUPPORT */
+
+/* Define to 1 if you have the `alarm' function. */
+#define HAVE_ALARM 1
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+/* #undef HAVE_ARPA_INET_H */
+
+/* Define to 1 if you have the <arpa/nameser.h> header file. */
+/* #undef HAVE_ARPA_NAMESER_H */
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY 1
+
+/* Define if you have the iconv() function and it works. */
+/* #undef HAVE_ICONV */
+
+/* Define to 1 if you have the `inet_ntoa' function. */
+/* #undef HAVE_INET_NTOA */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `duma' library (-lduma). */
+/* #undef HAVE_LIBDUMA */
+
+/* Define to 1 if you have the `dvbapi' library (-ldvbapi). */
+/* #undef HAVE_LIBDVBAPI */
+
+/* Define to 1 if you have the `dvbcsa' library (-ldvbcsa). */
+/* #undef HAVE_LIBDVBCSA */
+
+/* Define to 1 if you have the `dvben50221' library (-ldvben50221). */
+/* #undef HAVE_LIBDVBEN50221 */
+
+/* Define to 1 if you have the `m' library (-lm). */
+#define HAVE_LIBM 1
+
+/* Define to 1 if you have the `pthread' library (-lpthread). */
+#define HAVE_LIBPTHREAD 1
+
+/* Define to 1 if you have the `rt' library (-lrt). */
+/* #undef HAVE_LIBRT */
+
+/* Define to 1 if you have the `ucsi' library (-lucsi). */
+/* #undef HAVE_LIBUCSI */
+
+/* Define to 1 if you have the `memset' function. */
+#define HAVE_MEMSET 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+/* #undef HAVE_NETDB_H */
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+/* #undef HAVE_NETINET_IN_H */
+
+/* Define to 1 if you have the <resolv.h> header file. */
+/* #undef HAVE_RESOLV_H */
+
+/* Define to 1 if you have the `socket' function. */
+/* #undef HAVE_SOCKET */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strerror' function. */
+#define HAVE_STRERROR 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strstr' function. */
+#define HAVE_STRSTR 1
+
+/* Define to 1 if you have the <syslog.h> header file. */
+/* #undef HAVE_SYSLOG_H */
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+/* #undef HAVE_SYS_IOCTL_H */
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+/* #undef HAVE_SYS_SOCKET_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <values.h> header file. */
+/* #undef HAVE_VALUES_H */
+
+/* Define as const if the declaration of iconv() needs const. */
+#define ICONV_CONST
+
+/* Name of package */
+#define PACKAGE "mumudvb"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "mumudvb@braice.net"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "MuMuDVB"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "MuMuDVB 2.2.0_20220403_mumudvb2"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "mumudvb"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.2.0_20220403_mumudvb2"
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Define if you want the old code for tuning */
+/* #undef TUNE_OLD */
+
+/* Version number of package */
+#define VERSION "2.2.0_20220403_mumudvb2"
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT32_T */
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT8_T */
+
+/* Define to the type of a signed integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int32_t */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define to the type of an unsigned integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint16_t */
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint32_t */
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint8_t */

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -338,8 +338,7 @@ void set_filters(uint8_t *asked_pid, fds_t *fds)
  * @brief Close the file descriptors associated with the card
  * @param fds the structure with the file descriptors
  */
-void
-close_card_fd(fds_t *fds)
+void close_card_fd(fds_t *fds)
 {
 	int curr_pid = 0;
 
@@ -353,14 +352,21 @@ close_card_fd(fds_t *fds)
 	}
 
 	if(fds->fd_dvr)
+#ifndef _WIN32
 		close (fds->fd_dvr);
+#else
+		CloseHandle(fds->fd_dvr);
+#endif
 	fds->fd_dvr=0;
+
 	if(fds->fd_frontend)
+#ifndef _WIN32
 		close (fds->fd_frontend);
+#else
+		CloseHandle(fds->fd_frontend);
+#endif
 	fds->fd_frontend=0;
-
 }
-
 
 /**
  * @brief Function for the tread reading data from the card

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -30,6 +30,8 @@
  */
 
 #define _GNU_SOURCE
+#define _CRT_SECURE_NO_WARNINGS
+
 #include "dvb.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -424,9 +426,6 @@ void *read_card_thread_func(void* arg)
 	}
 	return NULL;
 }
-
-
-
 
 /** @brief : Read data from the card
  * This function have to be called after a poll to ensure there is data to read

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -35,10 +35,14 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
+#ifndef _WIN32
 #include <dirent.h>
+#include <unistd.h>
+#else
+#include <io.h>
+#endif
 #include <sys/types.h>
 #include "log.h"
-#include <unistd.h>
 #include <sys/stat.h>
 
 static char *log_module="DVB: ";
@@ -574,8 +578,9 @@ void show_card_capabilities( int card, int tuner )
 /** @brief : List the DVB cards of the system and their capabilities
  *
  */
-void list_dvb_cards ()
+void list_dvb_cards(void)
 {
+#ifndef DISABLE_DVB_API
 	DIR *dvb_dir;
 	log_message( log_module, MSG_INFO,"==================================");
 	log_message( log_module, MSG_INFO,"        DVB CARDS LISTING\n");
@@ -652,5 +657,5 @@ void list_dvb_cards ()
 		}
 		closedir(adapter_dir);
 	}
+#endif
 }
-

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -77,10 +77,10 @@ typedef struct strength_parameters_t{
 	fe_status_t festatus;
 	int strength, ber, snr, ub;
 	int ts_discontinuities;
-}strength_parameters_t;
+} strength_parameters_t;
 
 /** The parameters for the thread for reading the data from the card */
-typedef struct card_thread_parameters_t{
+typedef struct card_thread_parameters_t {
 	//mutex for the data buffer
 	pthread_mutex_t carddatamutex;
 	//Condition variable for locking the main program in order to wait for new data
@@ -95,20 +95,25 @@ typedef struct card_thread_parameters_t{
 	int thread_running;
 	/** Is main waiting ?*/
 	int main_waiting;
-}card_thread_parameters_t;
+} card_thread_parameters_t;
 
 void *read_card_thread_func(void* arg);
 
-
-
+#ifndef _WIN32
 int open_fe (int *fd_frontend, char *base_path, int tuner, int rw, int full_path);
-void set_ts_filt (int fd,uint16_t pid);
+#else
+int open_fe(HANDLE *fd_frontend, char *base_path, int tuner, int rw, int full_path);
+#endif
+void set_ts_filt(int fd,uint16_t pid);
 int create_card_fd(char *base_path, int tuner, uint8_t *asked_pid, fds_t *fds);
 void set_filters(uint8_t *asked_pid, fds_t *fds);
 void close_card_fd(fds_t *fds);
-
 void *show_power_func(void* arg);
+#ifndef _WIN32
 int card_read(int fd_dvr, unsigned char *dest_buffer, card_buffer_t *card_buffer);
-
+#else
+int card_read(HANDLE fd_dvr, unsigned char *dest_buffer, card_buffer_t *card_buffer);
+int dvb_poll(HANDLE fd_dvr, int timeout);
+#endif
 void list_dvb_cards(void);
 #endif

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -1,23 +1,23 @@
-/* 
+/*
  * mumudvb - UDP-ize a DVB transport stream.
  * Based on dvbstream by (C) Dave Chapman <dave@dchapman.com> 2001, 2002.
- * 
+ *
  * (C) 2004-2010 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net/
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -33,18 +33,23 @@
 #ifndef _DVB_H
 #define _DVB_H
 
-#include <syslog.h>
 #include <stdio.h>
+#ifndef _WIN32
+#include <syslog.h>
 #include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <resolv.h>
+#endif
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <resolv.h>
-#include <sys/poll.h>
+#include "config.h"
 
-// DVB includes:
+#ifndef DISABLE_DVB_API
+ // DVB includes:
 #include <linux/dvb/dmx.h>
 #include <linux/dvb/frontend.h>
+#endif
 
 #include "mumudvb.h"
 #include "tune.h"
@@ -105,5 +110,5 @@ void close_card_fd(fds_t *fds);
 void *show_power_func(void* arg);
 int card_read(int fd_dvr, unsigned char *dest_buffer, card_buffer_t *card_buffer);
 
-void list_dvb_cards ();
+void list_dvb_cards(void);
 #endif

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -39,9 +39,9 @@
 #include <sys/ioctl.h>
 #include <sys/poll.h>
 #include <resolv.h>
+#include <unistd.h>
 #endif
 #include <sys/stat.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include "config.h"
 

--- a/src/dvb_win32.c
+++ b/src/dvb_win32.c
@@ -1,0 +1,169 @@
+/* dvb.c
+ * MuMuDVB - Stream a DVB transport stream.
+ *
+ * (C) 2004-2013 Brice DUBOST
+ * (C) Dave Chapman <dave@dchapman.com> 2001, 2002.
+ *
+ * The latest version can be found at http://mumudvb.net
+ *
+ * Copyright notice:
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+
+ /** @file
+  * @brief dvb part (except tune) of mumudvb
+  * Ie : setting the filters, openning the file descriptors etc...
+  */
+
+#define _GNU_SOURCE
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "dvb.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include "log.h"
+#include <sys/stat.h>
+
+static char *log_module = "DVBW32: ";
+
+/**
+ * @brief Open the frontend associated with card
+ * Return 1 in case of succes, -1 otherwise
+ *
+ * @param fd_frontend the file descriptor for the frontend
+ * @param card the card number
+ */
+int open_fe(HANDLE *fd_frontend, char *base_path, int tuner, int rw, int full_path)
+{
+    char device_path[MAX_PATH] = { 0, };
+    HANDLE pipe = INVALID_HANDLE_VALUE;
+    int retries = 5;
+
+    /* we only support named pipes */
+    if (!full_path)
+        return -1;
+
+    /* generate named pipe based on tuner number */
+    snprintf(device_path, sizeof(device_path), "\\\\.\\pipe\\ISDB_TUNER%d", tuner);
+    do {
+        pipe = CreateFile(device_path, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
+        if (pipe != INVALID_HANDLE_VALUE)
+            break;
+
+        if (GetLastError() != ERROR_PIPE_BUSY) {
+            log_message(log_module, MSG_ERROR, "Cannot connect to tuner %d pipe (%s)\n", tuner, strerror(GetLastError()));
+            return -1;
+        }
+
+        if (!WaitNamedPipe(device_path, 2)) {
+            log_message(log_module, MSG_ERROR, "Cannot connect to tuner %d pipe (%s)\n", tuner, strerror(GetLastError()));
+            return -1;
+        }
+    } while (retries--);
+
+    /* pipe opened */
+
+    *fd_frontend = pipe;
+
+    return 1;
+}
+
+int dvb_poll(HANDLE fd_dvr, int timeout)
+{
+    DWORD avail = 0;
+
+    if (PeekNamedPipe(fd_dvr, NULL, 0, NULL, &avail, NULL)) {
+        if (avail > TS_PACKET_SIZE * 20)
+            return 1;
+
+        return 0;
+    }
+
+    return -1;
+}
+
+void set_ts_filt(int fd, uint16_t pid)
+{
+    (void)fd;
+    (void)pid;
+}
+
+void *show_power_func(void *arg)
+{
+    (void)arg;
+
+    return 0;
+}
+
+int create_card_fd(char *base_path, int tuner, uint8_t *asked_pid, fds_t *fds)
+{
+    (void)base_path;
+    (void)tuner;
+    (void)asked_pid;
+    (void)fds;
+
+    return 0;
+}
+
+/**
+ * @brief Open filters for the pids in asked_pid. This function update the asked_pid array and
+ * can be called more than one time if new pids are added (typical case autoconf)
+ * @param asked_pid the array of asked pids
+ */
+void set_filters(uint8_t *asked_pid, fds_t *fds)
+{
+    for (int curr_pid = 0; curr_pid < 8193; curr_pid++) {
+        if (asked_pid[curr_pid] == PID_ASKED) {
+            asked_pid[curr_pid] = PID_FILTERED;
+        }
+    }
+}
+
+void close_card_fd(fds_t *fds)
+{
+    (void)fds;
+}
+
+/* unused */
+void *read_card_thread_func(void *arg)
+{
+
+    (void)arg;
+
+    return 0;
+}
+
+int card_read(HANDLE fd_dvr, unsigned char *dest_buffer, card_buffer_t *card_buffer)
+{
+    DWORD bread = 0;
+
+    if (!ReadFile(fd_dvr, dest_buffer, TS_PACKET_SIZE * card_buffer->dvr_buffer_size, &bread, NULL)) {
+        log_message(log_module, MSG_ERROR, "Error reading tuner pipe, aborting (%s)\n", strerror(GetLastError()));
+        return -1;
+    }
+
+    return bread;
+}
+
+/* unused */
+void list_dvb_cards(void)
+{
+
+}

--- a/src/dvb_win32.c
+++ b/src/dvb_win32.c
@@ -73,7 +73,7 @@ int open_fe(HANDLE *fd_frontend, char *base_path, int tuner, int rw, int full_pa
     }
 
     /* generate named pipe based on tuner number */
-    snprintf(device_path, sizeof(device_path), "\\\\.\\pipe\\ISDB_TUNER%d", tuner);
+    snprintf(device_path, sizeof(device_path), "\\\\.\\pipe\\DVB_TUNER%d", tuner);
     do {
         pipe = CreateFile(device_path, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
         if (pipe != INVALID_HANDLE_VALUE)

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -1,0 +1,224 @@
+/*
+ * getopt - POSIX like getopt for Windows console Application
+ *
+ * win-c - Windows Console Library
+ * Copyright (c) 2015 Koji Takami
+ * Released under the MIT license
+ * https://github.com/takamin/win-c/blob/master/LICENSE
+ */
+#include <stdio.h>
+#include <string.h>
+#include "getopt.h"
+
+char* optarg = 0;
+int optind = 1;
+int opterr = 1;
+int optopt = 0;
+
+int postpone_count = 0;
+int nextchar = 0;
+
+static void postpone(int argc, char* const argv[], int index) {
+    char** nc_argv = (char**)argv;
+    char* p = nc_argv[index];
+    int j = index;
+    for(; j < argc - 1; j++) {
+        nc_argv[j] = nc_argv[j + 1];
+    }
+    nc_argv[argc - 1] = p;
+}
+static int postpone_noopt(int argc, char* const argv[], int index) {
+    int i = index;
+    for(; i < argc; i++) {
+        if(*(argv[i]) == '-') {
+            postpone(argc, argv, index);
+            return 1;
+        }
+    }
+    return 0;
+}
+static int _getopt_(int argc, char* const argv[],
+        const char* optstring,
+        const struct option* longopts, int* longindex)
+{
+    while(1) {
+        int c;
+        const char* optptr = 0;
+        if(optind >= argc - postpone_count) {
+            c = 0;
+            optarg = 0;
+            break;
+        }
+        c = *(argv[optind] + nextchar);
+        if(c == '\0') {
+            nextchar = 0;
+            ++optind;
+            continue;
+        }
+        if(nextchar == 0) {
+            if(optstring[0] != '+' && optstring[0] != '-') {
+                while(c != '-') {
+                    /* postpone non-opt parameter */
+                    if(!postpone_noopt(argc, argv, optind)) {
+                        break; /* all args are non-opt param */
+                    }
+                    ++postpone_count;
+                    c = *argv[optind];
+                }
+            }
+            if(c != '-') {
+                if(optstring[0] == '-') {
+                    optarg = argv[optind];
+                    nextchar = 0;
+                    ++optind;
+                    return 1;
+                }
+                break;
+            } else {
+                if(strcmp(argv[optind], "--") == 0) {
+                    optind++;
+                    break;
+                }
+                ++nextchar;
+                if(longopts != 0 && *(argv[optind] + 1) == '-') {
+                    char const* spec_long = argv[optind] + 2;
+                    char const* pos_eq = strchr(spec_long, '=');
+                    int spec_len = (pos_eq == NULL ? strlen(spec_long) : pos_eq - spec_long);
+                    int index_search = 0;
+                    int index_found = -1;
+                    const struct option* optdef = 0;
+                    while(longopts->name != 0) {
+                        if(strncmp(spec_long, longopts->name, spec_len) == 0) {
+                            if(optdef != 0) {
+                                if(opterr) {
+                                    fprintf(stderr, "ambiguous option: %s\n", spec_long);
+                                }
+                                return '?';
+                            }
+                            optdef = longopts;
+                            index_found = index_search;
+                        }
+                        longopts++;
+                        index_search++;
+                    }
+                    if(optdef == 0) {
+                        if(opterr) {
+                            fprintf(stderr, "no such a option: %s\n", spec_long);
+                        }
+                        return '?';
+                    }
+                    switch(optdef->has_arg) {
+                        case no_argument:
+                            optarg = 0;
+                            if(pos_eq != 0) {
+                                if(opterr) {
+                                    fprintf(stderr, "no argument for %s\n", optdef->name);
+                                }
+                                return '?';
+                            }
+                            break;
+                        case required_argument:
+                            if(pos_eq == NULL) {
+                                ++optind;
+                                optarg = argv[optind];
+                            } else {
+                                optarg = (char*)pos_eq + 1;
+                            }
+                            break;
+                    }
+                    ++optind;
+                    nextchar = 0;
+                    if(longindex != 0) {
+                        *longindex = index_found;
+                    }
+                    if(optdef->flag != 0) {
+                        *optdef->flag = optdef->val;
+                        return 0;
+                    }
+                    return optdef->val;
+                }
+                continue;
+            }
+        }
+        optptr = strchr(optstring, c);
+        if(optptr == NULL) {
+            optopt = c;
+            if(opterr) {
+                fprintf(stderr,
+                        "%s: invalid option -- %c\n",
+                        argv[0], c);
+            }
+            ++nextchar;
+            return '?';
+        }
+        if(*(optptr+1) != ':') {
+            nextchar++;
+            if(*(argv[optind] + nextchar) == '\0') {
+                ++optind;
+                nextchar = 0;
+            }
+            optarg = 0;
+        } else {
+            nextchar++;
+            if(*(argv[optind] + nextchar) != '\0') {
+                optarg = argv[optind] + nextchar;
+            } else {
+                ++optind;
+                if(optind < argc - postpone_count) {
+                    optarg = argv[optind];
+                } else {
+                    optopt = c;
+                    if(opterr) {
+                        fprintf(stderr,
+                            "%s: option requires an argument -- %c\n",
+                            argv[0], c);
+                    }
+                    if(optstring[0] == ':' ||
+                        (optstring[0] == '-' || optstring[0] == '+') &&
+                        optstring[1] == ':')
+                    {
+                        c = ':';
+                    } else {
+                        c = '?';
+                    }
+                }
+            }
+            ++optind;
+            nextchar = 0;
+        }
+        return c;
+    }
+
+    /* end of option analysis */
+
+    /* fix the order of non-opt params to original */
+    while((argc - optind - postpone_count) > 0) {
+        postpone(argc, argv, optind);
+        ++postpone_count;
+    }
+
+    nextchar = 0;
+    postpone_count = 0;
+    return -1;
+}
+
+int getopt(int argc, char* const argv[],
+            const char* optstring)
+{
+    return _getopt_(argc, argv, optstring, 0, 0);
+}
+int getopt_long(int argc, char* const argv[],
+        const char* optstring,
+        const struct option* longopts, int* longindex)
+{
+    return _getopt_(argc, argv, optstring, longopts, longindex);
+}
+/********************************************************
+int getopt_long_only(int argc, char* const argv[],
+        const char* optstring,
+        const struct option* longopts, int* longindex)
+{
+    return -1;
+}
+********************************************************/
+

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -1,0 +1,44 @@
+/*
+ * getopt - POSIX like getopt for Windows console Application
+ *
+ * win-c - Windows Console Library
+ * Copyright (c) 2015 Koji Takami
+ * Released under the MIT license
+ * https://github.com/takamin/win-c/blob/master/LICENSE
+ */
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+    int getopt(int argc, char* const argv[],
+            const char* optstring);
+
+    extern char *optarg;
+    extern int optind, opterr, optopt;
+
+#define no_argument 0
+#define required_argument 1
+#define optional_argument 2
+
+    struct option {
+        const char *name;
+        int has_arg;
+        int* flag;
+        int val;
+    };
+
+    int getopt_long(int argc, char* const argv[],
+            const char* optstring,
+            const struct option* longopts, int* longindex);
+/****************************************************************************
+    int getopt_long_only(int argc, char* const argv[],
+            const char* optstring,
+            const struct option* longopts, int* longindex);
+****************************************************************************/
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GETOPT_H_

--- a/src/log.c
+++ b/src/log.c
@@ -1,23 +1,23 @@
-/* 
+/*
  * mumudvb - Stream a DVB transport stream.
  * Based on dvbstream by (C) Dave Chapman <dave@dchapman.com> 2001, 2002.
- * 
+ *
  * (C) 2004-2013 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -26,22 +26,30 @@
 
 /** @file
  * @brief Log functions for mumudvb
- * 
+ *
  * This file contains functions to log messages or write logging information to a file
  */
+
+#define _POSIX_C_SOURCE 200809L
 
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
+#ifndef _WIN32
 #include <syslog.h>
+#endif
 #include <errno.h>
-#include <linux/dvb/version.h>
 #include <time.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <inttypes.h>
 
+#include "config.h"
+
+#ifndef DISABLE_DVB_API
+#include <linux/dvb/version.h>
+#endif
 
 #include "mumudvb.h"
 #include "errors.h"
@@ -140,12 +148,14 @@ int read_logging_configuration(stats_infos_t *stats_infos, char *substring)
 		substring = strtok (NULL, delimiteurs);
 		if (!strcmp (substring, "console"))
 			log_params.log_type |= LOGGING_CONSOLE;
+#ifndef _WIN32
 		else if (!strcmp (substring, "syslog"))
 		{
 			openlog ("MUMUDVB", LOG_PID, 0);
 			log_params.log_type |= LOGGING_SYSLOG;
 			log_params.syslog_initialised=1;
 		}
+#endif
 		else
 			log_message(log_module,MSG_WARN,"Invalid value for log_type\n");
 	}
@@ -280,8 +290,10 @@ void log_message( char* log_module, int type,
 		{
 			if (log_params.log_type == LOGGING_FILE)
 				fprintf( log_params.log_file,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
+#ifndef _WIN32
 			else if (log_params.log_type == LOGGING_SYSLOG)
 				syslog (MSG_ERROR,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
+#endif
 			else
 				fprintf( stderr,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
 			va_end( args );
@@ -329,8 +341,10 @@ void log_message( char* log_module, int type,
 	{
 		if (log_params.log_type == LOGGING_FILE)
 			fprintf( log_params.log_file,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
+#ifndef _WIN32
 		else if (log_params.log_type == LOGGING_SYSLOG)
 			syslog (MSG_ERROR,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
+#endif
 		else
 			fprintf( stderr,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
 		va_end( args );
@@ -355,6 +369,7 @@ void log_message( char* log_module, int type,
 	{
 		if ( log_params.log_type & LOGGING_FILE)
 			fprintf(log_params.log_file,"%s",log_string.string);
+#ifndef _WIN32
 		if((log_params.log_type & LOGGING_SYSLOG) && (log_params.syslog_initialised))
 		{
 			//what is the priority ?
@@ -382,13 +397,13 @@ void log_message( char* log_module, int type,
 			}
 			syslog (priority,"%s",log_string.string);
 		}
+#endif
 		if((log_params.log_type == LOGGING_UNDEFINED) ||
 				(log_params.log_type & LOGGING_CONSOLE) ||
 				((log_params.log_type & LOGGING_SYSLOG) && (log_params.syslog_initialised==0)))
 			fprintf(stderr,"%s",log_string.string);
 	}
 	mumu_free_string(&log_string);
-
 }
 
 /**
@@ -673,7 +688,7 @@ ca_sys_id_t casysids[]={
 int num_casysids=130;
 
 
-/** @brief Display the ca system id according to ETR 162 
+/** @brief Display the ca system id according to ETR 162
  *
  * @param id the id to display
  */
@@ -965,7 +980,7 @@ void print_info ()
 			"by Brice DUBOST (mumudvb@braice.net)\n\n"
 #if DVB_API_VERSION >= 5
 			,DVB_API_VERSION,DVB_API_VERSION_MINOR
-#endif			
+#endif
 			);
 
 }

--- a/src/log.c
+++ b/src/log.c
@@ -42,6 +42,7 @@
 #include <unistd.h>
 #else
 #include <process.h> /* for getpid() */
+#define getpid() _getpid()
 #endif
 #include <errno.h>
 #include <time.h>
@@ -330,7 +331,7 @@ void log_message( char* log_module, int type,
 	log_string.string=mumu_string_replace(log_string.string,&log_string.length,1,"%date",timestring);
 
 	char pidstring[10];
-	sprintf (pidstring, "%d", getpid ());
+	sprintf (pidstring, "%d", getpid());
 	log_string.string=mumu_string_replace(log_string.string,&log_string.length,1,"%pid",pidstring);
 
 
@@ -1020,10 +1021,10 @@ void show_traffic( char *log_module, double now, int show_traffic_interval, mumu
 	static long show_traffic_time=0;
 
 	if(!show_traffic_time)
-		show_traffic_time=now;
+		show_traffic_time = (long)now;
 	if((now-show_traffic_time)>=show_traffic_interval)
 	{
-		show_traffic_time=now;
+		show_traffic_time = (long)now;
 		for (int curr_channel = 0; curr_channel < chan_p->number_of_channels; curr_channel++)
 		{
 			log_message( log_module,  MSG_INFO, "Traffic :  %.2f kb/s \t  for channel \"%s\"\n",
@@ -1067,7 +1068,9 @@ int convert_en300468_string(char *string, int max_len, int debug)
 
 	int encoding_control_char=8; //cf encodings_en300468
 	char *tempdest, *tempbuf;
+#ifdef HAVE_ICONV
 	char *dest;
+#endif
 	unsigned char *realstart;
 	unsigned char *src;
 	/* remove control characters and convert to UTF-8 the channel name */
@@ -1208,7 +1211,10 @@ int convert_en300468_string(char *string, int max_len, int debug)
 #else
 	if(debug) {log_message( log_module, MSG_DETAIL, "Iconv not present, no name encoding conversion \n");}
 #endif
+
+#ifdef HAVE_ICONV
 exit_iconv:
+#endif
 	if(debug) {log_message( log_module, MSG_FLOOD, "Converted text : \"%s\" (text encoding : %s)\n", string,encodings_en300468[encoding_control_char]);}
 
 	return encoding_control_char;

--- a/src/log.c
+++ b/src/log.c
@@ -31,6 +31,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L
+#define _CRT_SECURE_NO_WARNINGS
 
 #include <stdio.h>
 #include <string.h>
@@ -39,6 +40,8 @@
 #ifndef _WIN32
 #include <syslog.h>
 #include <unistd.h>
+#else
+#include <process.h> /* for getpid() */
 #endif
 #include <errno.h>
 #include <time.h>
@@ -186,7 +189,7 @@ int read_logging_configuration(stats_infos_t *stats_infos, char *substring)
 	else if (!strcmp (substring, "log_flush_interval"))
 	{
 		substring = strtok (NULL, delimiteurs);
-		log_params.log_flush_interval = atof (substring);
+		log_params.log_flush_interval = (float)atof(substring);
 	}
 	else
 		return 0;
@@ -1209,10 +1212,7 @@ exit_iconv:
 	if(debug) {log_message( log_module, MSG_FLOOD, "Converted text : \"%s\" (text encoding : %s)\n", string,encodings_en300468[encoding_control_char]);}
 
 	return encoding_control_char;
-
 }
-
-
 
 /** @brief : show the contents of the CA identifier descriptor
  *

--- a/src/log.c
+++ b/src/log.c
@@ -38,11 +38,11 @@
 #include <stddef.h>
 #ifndef _WIN32
 #include <syslog.h>
+#include <unistd.h>
 #endif
 #include <errno.h>
 #include <time.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <inttypes.h>
 
 #include "config.h"
@@ -318,7 +318,11 @@ void log_message( char* log_module, int type,
 	actual_time=time(NULL);
 	sprintf(timestring,"%jd", (intmax_t)actual_time);
 	log_string.string=mumu_string_replace(log_string.string,&log_string.length,1,"%timeepoch",timestring);
+#ifndef _WIN32
 	asctime_r(localtime(&actual_time),timestring);
+#else
+	asctime_s(timestring, sizeof(timestring), localtime(&actual_time));
+#endif
 	timestring[strlen(timestring)-1]='\0'; //In order to remove the final '\n' but by asctime
 	log_string.string=mumu_string_replace(log_string.string,&log_string.length,1,"%date",timestring);
 

--- a/src/log.h
+++ b/src/log.h
@@ -1,27 +1,27 @@
-/* 
+/*
  * MuMuDVB - UDP-ize a DVB transport stream.
- * 
+ *
  * (C) 2009 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net/
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
- 
+
 #ifndef _LOG_H
 #define _LOG_H
 
@@ -107,7 +107,11 @@ typedef struct flag_descr_t
 void init_stats_v(stats_infos_t *stats_p);
 void print_info ();
 void usage (char *name);
+#ifndef _WIN32
 void log_message( char* log_module, int , const char *, ... ) __attribute__ ((format (printf, 3, 4)));
+#else
+void log_message(char *log_module, int, const char *, ...);
+#endif
 void gen_file_streamed_channels (char *nom_fich_chaines_diff, char *nom_fich_chaines_non_diff, int nb_flux, mumudvb_channel_t *channels);
 void log_streamed_channels(char *log_module,int number_of_channels, mumudvb_channel_t *channels, int multicast_ipv4, int multicast_ipv6, int unicast, int unicast_master_port, char *unicastipOut);
 char *ca_sys_id_to_str(int id);

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -13,24 +13,26 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  *
  */
- 
+
 
 
 #include "mumudvb.h"
 #include "log.h"
 #include <string.h>
+#ifndef _WIN32
 #include <net/if.h>
+#endif
 static char *log_module="Multicast: ";
 
 
@@ -171,5 +173,5 @@ int read_multicast_configuration(multi_p_t *multi_p, mumudvb_channel_t *c_chan, 
     return 0; //Nothing concerning multicast, we return 0 to explore the other possibilities
 
   return 1;//We found something for multicast, we tell main to go for the next line
-  
+
 }

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -34,144 +34,106 @@
 #include <net/if.h>
 #endif
 
-static char *log_module="Multicast: ";
+static char *log_module = "Multicast: ";
 
 /** Initialize multicast variables*/
 void init_multicast_v(multi_p_t *multi_p)
 {
-	memset(multi_p,0,sizeof(multi_p_t));
-	 *multi_p=(multi_p_t){
-	 		.multicast=1,
-	 		.multicast_ipv6=0,
-	 		.multicast_ipv4=1,
-	 		.ttl=DEFAULT_TTL,
-	 		.common_port = 1234,
-	 		.auto_join=0,
-	 		.rtp_header = 0,
-	 		.iface4="\0",
-	 		.iface6="\0",
-	 };
+    memset(multi_p, 0, sizeof(multi_p_t));
+    *multi_p = (multi_p_t) {
+        .multicast = 1,
+        .multicast_ipv6 = 0,
+        .multicast_ipv4 = 1,
+        .ttl = DEFAULT_TTL,
+        .common_port = 1234,
+        .auto_join = 0,
+        .rtp_header = 0,
+        .iface4 = "\0",
+        .iface6 = "\0",
+    };
 
 }
 
-
- /** @brief Read a line of the configuration file to check if there is a cam parameter
- *
- * @param multi_p the multicast parameters
- * @param substring The currrent line
-  */
-int read_multicast_configuration(multi_p_t *multi_p, mumudvb_channel_t *c_chan,  char *substring)
+/** @brief Read a line of the configuration file to check if there is a cam parameter
+*
+* @param multi_p the multicast parameters
+* @param substring The currrent line
+ */
+int read_multicast_configuration(multi_p_t *multi_p, mumudvb_channel_t *c_chan, char *substring)
 {
-  char delimiteurs[] = CONFIG_FILE_SEPARATOR;
+    char delimiteurs[] = CONFIG_FILE_SEPARATOR;
 
-  if (!strcmp (substring, "common_port"))
-  {
-    substring = strtok (NULL, delimiteurs);
-    multi_p->common_port = atoi (substring);
-  }
-  else if (!strcmp (substring, "multicast_ttl"))
-  {
-    substring = strtok (NULL, delimiteurs);
-    multi_p->ttl = atoi (substring);
-  }
-  else if (!strcmp (substring, "multicast_ipv4"))
-  {
-    substring = strtok (NULL, delimiteurs);
-    multi_p->multicast_ipv4 = atoi (substring);
-  }
-  else if (!strcmp (substring, "multicast_ipv6"))
-  {
-    substring = strtok (NULL, delimiteurs);
-    multi_p->multicast_ipv6 = atoi (substring);
-  }
-  else if (!strcmp (substring, "multicast_auto_join"))
-  {
-    substring = strtok (NULL, delimiteurs);
-    multi_p->auto_join = atoi (substring);
-  }
-  else if (!strcmp (substring, "ip"))
-  {
-	if ( c_chan == NULL)
-    {
-      log_message( log_module,  MSG_ERROR,
-                   "ip : You have to start a channel first (using new_channel)\n");
-      return -1;
+    if (!strcmp(substring, "common_port")) {
+        substring = strtok(NULL, delimiteurs);
+        multi_p->common_port = atoi(substring);
+    } else if (!strcmp(substring, "multicast_ttl")) {
+        substring = strtok(NULL, delimiteurs);
+        multi_p->ttl = atoi(substring);
+    } else if (!strcmp(substring, "multicast_ipv4")) {
+        substring = strtok(NULL, delimiteurs);
+        multi_p->multicast_ipv4 = atoi(substring);
+    } else if (!strcmp(substring, "multicast_ipv6")) {
+        substring = strtok(NULL, delimiteurs);
+        multi_p->multicast_ipv6 = atoi(substring);
+    } else if (!strcmp(substring, "multicast_auto_join")) {
+        substring = strtok(NULL, delimiteurs);
+        multi_p->auto_join = atoi(substring);
+    } else if (!strcmp(substring, "ip")) {
+        if (c_chan == NULL) {
+            log_message(log_module, MSG_ERROR, "ip : You have to start a channel first (using new_channel)\n");
+            return -1;
+        }
+
+        substring = strtok(NULL, delimiteurs);
+        if (strlen(substring) > 19) {
+            log_message(log_module, MSG_ERROR, "The Ip address %s is too long.\n", substring);
+            return -1;
+        }
+        sscanf(substring, "%s\n", c_chan->ip4Out);
+        MU_F(c_chan->ip4Out) = F_USER;
+    } else if (!strcmp(substring, "ip6")) {
+        if (c_chan == NULL) {
+            log_message(log_module, MSG_ERROR, "ip6 : You have to start a channel first (using new_channel)\n");
+            return -1;
+        }
+
+        substring = strtok(NULL, delimiteurs);
+        if (strlen(substring) > (IPV6_CHAR_LEN - 1)) {
+            log_message(log_module, MSG_ERROR, "The Ip v6 address %s is too long.\n", substring);
+            return -1;
+        }
+        sscanf(substring, "%s\n", c_chan->ip6Out);
+        MU_F(c_chan->ip6Out) = F_USER;
+    } else if (!strcmp(substring, "port")) {
+        if (c_chan == NULL) {
+            log_message(log_module, MSG_ERROR, "port : You have to start a channel first (using new_channel)\n");
+            return -1;
+        }
+        substring = strtok(NULL, delimiteurs);
+        c_chan->portOut = atoi(substring);
+        MU_F(c_chan->portOut) = F_USER;
+    } else if (!strcmp(substring, "rtp_header")) {
+        substring = strtok(NULL, delimiteurs);
+        multi_p->rtp_header = atoi(substring);
+        if (multi_p->rtp_header == 1)
+            log_message(log_module, MSG_INFO, "You decided to send the RTP header (multicast only).\n");
+    } else if (!strcmp(substring, "multicast_iface4")) {
+        substring = strtok(NULL, delimiteurs);
+        if (strlen(substring) > (IF_NAMESIZE)) {
+            log_message(log_module, MSG_ERROR, "The interface name ipv4 address %s is too long.\n", substring);
+            return -1;
+        }
+        sscanf(substring, "%s\n", multi_p->iface4);
+    } else if (!strcmp(substring, "multicast_iface6")) {
+        substring = strtok(NULL, delimiteurs);
+        if (strlen(substring) > (IF_NAMESIZE)) {
+            log_message(log_module, MSG_ERROR, "The interface name ipv6 address %s is too long.\n", substring);
+            return -1;
+        }
+        sscanf(substring, "%s\n", multi_p->iface6);
+    } else {
+        return 0; //Nothing concerning multicast, we return 0 to explore the other possibilities
     }
 
-    substring = strtok (NULL, delimiteurs);
-    if(strlen(substring)>19)
-    {
-      log_message( log_module,  MSG_ERROR,
-                   "The Ip address %s is too long.\n", substring);
-      return -1;
-    }
-    sscanf (substring, "%s\n", c_chan->ip4Out);
-    MU_F(c_chan->ip4Out)=F_USER;
-  }
-  else if (!strcmp (substring, "ip6"))
-  {
-	if ( c_chan == NULL)
-    {
-      log_message( log_module,  MSG_ERROR,
-                   "ip6 : You have to start a channel first (using new_channel)\n");
-      return -1;
-    }
-
-    substring = strtok (NULL, delimiteurs);
-    if(strlen(substring)>(IPV6_CHAR_LEN-1))
-    {
-      log_message( log_module,  MSG_ERROR,
-                   "The Ip v6 address %s is too long.\n", substring);
-      return -1;
-    }
-    sscanf (substring, "%s\n", c_chan->ip6Out);
-    MU_F(c_chan->ip6Out)=F_USER;
-  }
-
-  else if (!strcmp (substring, "port"))
-  {
-	if ( c_chan == NULL)
-    {
-      log_message( log_module,  MSG_ERROR,
-                   "port : You have to start a channel first (using new_channel)\n");
-      return -1;
-    }
-    substring = strtok (NULL, delimiteurs);
-    c_chan->portOut = atoi (substring);
-    MU_F(c_chan->portOut)=F_USER;
-  }
-  else if (!strcmp (substring, "rtp_header"))
-  {
-    substring = strtok (NULL, delimiteurs);
-    multi_p->rtp_header = atoi (substring);
-    if (multi_p->rtp_header==1)
-      log_message( log_module,  MSG_INFO, "You decided to send the RTP header (multicast only).\n");
-  }
-  else if (!strcmp (substring, "multicast_iface4"))
-  {
-    substring = strtok (NULL, delimiteurs);
-    if(strlen(substring)>(IF_NAMESIZE))
-    {
-      log_message( log_module,  MSG_ERROR,
-                   "The interface name ipv4 address %s is too long.\n", substring);
-      return -1;
-    }
-    sscanf (substring, "%s\n", multi_p->iface4);
-  }
-  else if (!strcmp (substring, "multicast_iface6"))
-  {
-    substring = strtok (NULL, delimiteurs);
-    if(strlen(substring)>(IF_NAMESIZE))
-    {
-      log_message( log_module,  MSG_ERROR,
-                   "The interface name ipv6 address %s is too long.\n", substring);
-      return -1;
-    }
-    sscanf (substring, "%s\n", multi_p->iface6);
-  }
-  else
-    return 0; //Nothing concerning multicast, we return 0 to explore the other possibilities
-
-  return 1;//We found something for multicast, we tell main to go for the next line
-
+    return 1; //We found something for multicast, we tell main to go for the next line
 }

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -25,7 +25,7 @@
  *
  */
 
-
+#define _CRT_SECURE_NO_WARNINGS
 
 #include "mumudvb.h"
 #include "log.h"
@@ -33,8 +33,8 @@
 #ifndef _WIN32
 #include <net/if.h>
 #endif
-static char *log_module="Multicast: ";
 
+static char *log_module="Multicast: ";
 
 /** Initialize multicast variables*/
 void init_multicast_v(multi_p_t *multi_p)

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -122,6 +122,9 @@
 #endif
 #ifndef _WIN32
 #include <sys/mman.h>
+#else
+#include <process.h> /* for getpid() */
+#define getpid() _getpid()
 #endif
 #include <pthread.h>
 
@@ -957,7 +960,7 @@ int main (int argc, char **argv)
 						filename_pid, strerror (errno));
 				exit(ERROR_CREATE_FILE);
 			}
-			fprintf (pidfile, "%d\n", getpid ());
+			fprintf (pidfile, "%d\n", getpid());
 			fclose (pidfile);
 		}
 

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -1229,7 +1229,7 @@ int main (int argc, char **argv)
 	if(unic_p.unicast)
 	{
 		log_message("Unicast: ", MSG_INFO,"We open the Master http socket for address %s:%d\n",unic_p.ipOut, unic_p.portOut);
-		unicast_create_listening_socket(UNICAST_MASTER, -1, unic_p.ipOut, unic_p.portOut, &unic_p.sIn, &unic_p.socketIn, &unic_p);
+		unicast_create_listening_socket(UNICAST_MASTER, -1, unic_p.ipOut, unic_p.portOut, &unic_p.socketIn, &unic_p);
 	}
 	update_chan_net(&chan_p, &auto_p, &multi_p, &unic_p, server_id, tune_p.card, tune_p.tuner);
 

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -902,7 +902,7 @@ main (int argc, char **argv)
 		log_message( log_module,  MSG_DEBUG,
 				"Opening source file %s", tune_p.read_file_path);
 
-		iRet = open_fe (&fds.fd_frontend, tune_p.read_file_path, tune_p.tuner,1,1);
+		iRet = open_fe (&fds.fd_dvr, tune_p.read_file_path, tune_p.tuner,1,1);
 	}
 	else
 		iRet = open_fe (&fds.fd_frontend, tune_p.card_dev_path, tune_p.tuner,1,0);

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -919,14 +919,18 @@ int main (int argc, char **argv)
 	// We tune the card
 	iRet =-1;
 
-	if(strlen(tune_p.read_file_path))
-	{
+	if (strlen(tune_p.read_file_path)) {
 		log_message( log_module,  MSG_DEBUG, "Opening source file %s", tune_p.read_file_path);
 
 		iRet = open_fe (&fds.fd_dvr, tune_p.read_file_path, tune_p.tuner,1,1);
+	} else {
+#ifndef _WIN32
+		iRet = open_fe(&fds.fd_frontend, tune_p.card_dev_path, tune_p.tuner, 1, 0);
+#else
+		iRet = open_fe(&fds.fd_dvr, NULL, tune_p.tuner, 1, 1);  /* Under windows, we only support named pipes */
+#endif
 	}
-	else
-		iRet = open_fe (&fds.fd_frontend, tune_p.card_dev_path, tune_p.tuner,1,0);
+
 	if (iRet>0)
 	{
 
@@ -963,6 +967,7 @@ int main (int argc, char **argv)
 		else
 			iRet = tune_it(fds.fd_frontend, &tune_p);
 #else
+		/* No tuning on windows at all */
 		iRet = 1;
 #endif
 	}

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -213,9 +213,7 @@ typedef struct fds_t {
 	int fd_dvr;
 #endif
 	/** the dvb frontend*/
-#ifdef _WIN32
-	HANDLE fd_frontend;
-#else
+#ifndef _WIN32
 	int fd_frontend;
 #endif
 	/** demuxer file descriptors */

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -1,23 +1,23 @@
-/* 
+/*
  * MuMuDVB - Stream a DVB transport stream.
  * Based on dvbstream by (C) Dave Chapman <dave@dchapman.com> 2001, 2002.
- * 
+ *
  * (C) 2004-2010 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net/
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -36,7 +36,9 @@
 #include "ts.h"
 #include "config.h"
 #include <pthread.h>
+#ifndef _WIN32
 #include <net/if.h>
+#endif
 
 #define MAX_FILENAME_LEN 256
 
@@ -90,8 +92,7 @@
 #define ALARM_TIME_TIMEOUT 60
 #define ALARM_TIME_TIMEOUT_NO_DIFF 600
 
-
-/** MTU 
+/** MTU
     1500 bytes - ip header (12bytes) - TCP header (biggest between TCP and udp) 24  : 7 mpeg2-ts packet per ethernet frame
 
 We cannot discover easily the MTU with unconnected UDP
@@ -235,7 +236,7 @@ typedef struct {
 	unsigned int to_send;
 	/** Read index of buffer for sending thread */
 	unsigned int read_send_idx;
-}ring_buffer_t;  
+}ring_buffer_t;
 #endif
 
 /**@brief Structure containing the card buffers*/
@@ -308,7 +309,7 @@ typedef enum chan_status {
  * All members are protected by the global lock in chan_p, with the
  * following exceptions:
  *
- *  - The EIT variables, since they are only ever accessed from the main thread. 
+ *  - The EIT variables, since they are only ever accessed from the main thread.
  *  - buf/nb_bytes, since they are only ever accessed from one thread: SCAM_SEND
  *    if we are using scam, or the main thread otherwise.
  *  - the odd/even keys, since they have their own locking.

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -472,8 +472,6 @@ typedef struct mumudvb_channel_t{
 	/**Unicast port (listening socket per channel) */
 	MU_F_V(int,unicast_port)
 	/**Unicast listening socket*/
-	struct sockaddr_in sIn;
-	/**Unicast listening socket*/
 	int socketIn;
 
 	/**The sap playlist group*/

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -38,6 +38,8 @@
 #include <pthread.h>
 #ifndef _WIN32
 #include <net/if.h>
+#else
+#include "win32.h"
 #endif
 
 #define MAX_FILENAME_LEN 256
@@ -158,7 +160,7 @@ typedef enum option_status {
 } option_status_t;
 
 /** Enum to tell if a channel parameter is user set or autodetected, to avoid erasing of user set params*/
-typedef enum mumu_f {
+typedef enum mumu_f_t {
 	F_UNDEF,
 	F_USER,
 	F_DETECTED
@@ -314,8 +316,7 @@ typedef enum chan_status {
  *    if we are using scam, or the main thread otherwise.
  *  - the odd/even keys, since they have their own locking.
  */
-typedef struct mumu_chan_t{
-
+typedef struct mumudvb_channel_t{
 	/** Flag to say the channel is ready for streaming */
 	chan_status_t channel_ready;
 
@@ -341,7 +342,7 @@ typedef struct mumu_chan_t{
 	/**the channel name*/
 	char user_name[MAX_NAME_LEN];
 	char name[MAX_NAME_LEN];
-	MU_F_T(name);
+	mumu_f_t name_f; /* MU_F_T(name); */
 	char service_name[MAX_NAME_LEN];
 
 	/* The PID information for this channel*/
@@ -350,10 +351,12 @@ typedef struct mumu_chan_t{
 	/** The service Type from the SDT */
 	int service_type;
 	/**Transport stream ID*/
-	MU_F_V(int,service_id);
+	int service_id;
+	mumu_f_t service_id_f; /* MU_F_V(int,service_id); */
 
 	/**Say if we need to ask this channel to the cam*/
-	MU_F_V(int,need_cam_ask);
+	int need_cam_ask;
+	mumu_f_t need_cam_ask_f; /* MU_F_V(int,need_cam_ask); */
 	/** When did we asked the channel to the CAM */
 	long cam_asking_time;
 	/**The ca system ids*/
@@ -469,7 +472,7 @@ typedef struct mumu_chan_t{
 
 	/**The sap playlist group*/
 	char sap_group[SAP_GROUP_LENGTH];
-	MU_F_T(sap_group);
+	mumu_f_t sap_group_f; /* MU_F_T(sap_group); */
 	//do we need to update the SAP announce (typically a name change)
 	int sap_need_update;
 
@@ -615,13 +618,13 @@ int mumu_init_chan(mumudvb_channel_t *chan);
 void chan_update_CAM(mumu_chan_p_t *chan_p, struct auto_p_t *auto_p,  void *scam_vars_v);
 void update_chan_net(mumu_chan_p_t *chan_p, struct auto_p_t *auto_p, multi_p_t *multi_p, struct unicast_parameters_t *unicast_vars, int server_id, int card, int tuner);
 void update_chan_filters(mumu_chan_p_t *chan_p, char *card_base_path, int tuner, fds_t *fds);
-long int mumu_timing();
+long int mumu_timing(void);
 
 /** Sets the interrupted flag if value != 0 and it is not already set.
  * In any case, returns the given value back. Thread- and signal-safe. */
 int set_interrupted(int value);
 
 /** Gets the interrupted flag; 0 if we have not been interrupted. */
-int get_interrupted();
+int get_interrupted(void);
 
 #endif

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -205,17 +205,25 @@ enum
 };
 
 /**@brief file descriptors*/
-typedef struct {
+typedef struct fds_t {
 	/** the dvb dvr*/
+#ifdef _WIN32
+	HANDLE fd_dvr;
+#else
 	int fd_dvr;
+#endif
 	/** the dvb frontend*/
+#ifdef _WIN32
+	HANDLE fd_frontend;
+#else
 	int fd_frontend;
+#endif
 	/** demuxer file descriptors */
 	int fd_demuxer[8193];
 	/** poll file descriptors */
 	struct pollfd *pfds;	//  DVR device
 	int pfdsnum;
-}fds_t;
+} fds_t;
 
 #ifdef ENABLE_SCAM_SUPPORT
 /**@brief Structure containing ring buffer*/

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -216,6 +216,8 @@ typedef struct fds_t {
 #ifndef _WIN32
 	int fd_frontend;
 #endif
+	/** udp source socket */
+	int fd_source;
 	/** demuxer file descriptors */
 	int fd_demuxer[8193];
 	/** poll file descriptors */

--- a/src/mumudvb_channels.c
+++ b/src/mumudvb_channels.c
@@ -24,8 +24,7 @@
  *
  */
 
-
-
+#define _CRT_SECURE_NO_WARNINGS
 
 #include "mumudvb.h"
 #include "log.h"

--- a/src/mumudvb_channels.c
+++ b/src/mumudvb_channels.c
@@ -36,8 +36,8 @@
 
 #ifndef _WIN32
 #include <sys/poll.h>
-#endif
 #include <sys/time.h>
+#endif
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
@@ -47,6 +47,10 @@
 
 #ifdef ENABLE_SCAM_SUPPORT
 #include "scam_common.h"
+#endif
+
+#ifdef _MSC_VER
+#define strtok_r strtok_s
 #endif
 
 static char *log_module="Common chan: ";
@@ -91,11 +95,10 @@ int mumu_init_chan(mumudvb_channel_t *chan)
 		}
 	}
 
-#ifdef ENABLE_SCAM_SUPPORT
 	pthread_mutex_init(&chan->stats_lock, NULL);
+#ifdef ENABLE_SCAM_SUPPORT
 	pthread_mutex_init(&chan->cw_lock, NULL);
 	chan->camd_socket = -1;
-
 #endif
 	return 0;
 }

--- a/src/mumudvb_channels.c
+++ b/src/mumudvb_channels.c
@@ -391,7 +391,6 @@ void update_chan_net(mumu_chan_p_t *chan_p, auto_p_t *auto_p, multi_p_t *multi_p
 					ichan,
 					unicast_vars->ipOut,
 					chan_p->channels[ichan].unicast_port,
-					&chan_p->channels[ichan].sIn,
 					&chan_p->channels[ichan].socketIn,
 					unicast_vars);
 		}

--- a/src/mumudvb_channels.c
+++ b/src/mumudvb_channels.c
@@ -500,9 +500,10 @@ void update_chan_filters(mumu_chan_p_t *chan_p, char *card_base_path, int tuner,
 		//Now we have the PIDs we look for those who disappeared
 		if(chan_p->asked_pid[ipid]==PID_ASKED && asked_pid[ipid]!=PID_ASKED && ipid != PSIP_PID)
 		{
-			log_message( log_module,  MSG_INFO, "Update : PID %d does not belong to any channel anymore, we close the filter",
-					ipid);
+			log_message( log_module,  MSG_INFO, "Update : PID %d does not belong to any channel anymore, we close the filter", ipid);
+#ifndef _WIN32
 			close(fds->fd_demuxer[ipid]);
+#endif
 			fds->fd_demuxer[ipid]=0;
 			chan_p->asked_pid[ipid]=PID_NOT_ASKED;
 		}
@@ -528,41 +529,3 @@ void update_chan_filters(mumu_chan_p_t *chan_p, char *card_base_path, int tuner,
 
 	pthread_mutex_unlock(&chan_p->lock);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/mumudvb_channels.c
+++ b/src/mumudvb_channels.c
@@ -1,23 +1,23 @@
-/* 
+/*
  * MuMuDVB - Stream a DVB transport stream.
  * Based on dvbstream by (C) Dave Chapman <dave@dchapman.com> 2001, 2002.
- * 
+ *
  * (C) 2014 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -34,14 +34,20 @@
 #include "rtp.h"
 #include "unicast_http.h"
 
+#ifndef _WIN32
 #include <sys/poll.h>
+#endif
 #include <sys/time.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include "scam_common.h"
 
+#include "autoconf.h"
+
+#ifdef ENABLE_SCAM_SUPPORT
+#include "scam_common.h"
+#endif
 
 static char *log_module="Common chan: ";
 
@@ -197,7 +203,6 @@ void chan_new_pmt(unsigned char *ts_packet, mumu_chan_p_t *chan_p, int pid)
 	}
 }
 
-
 /** @brief Update the CAM information for the channels
  */
 void chan_update_CAM(mumu_chan_p_t *chan_p, auto_p_t *auto_p,  void *scam_vars_v)
@@ -243,7 +248,7 @@ void chan_update_CAM(mumu_chan_p_t *chan_p, auto_p_t *auto_p,  void *scam_vars_v
 				}
 				memset (chan_p->channels[ichan].scam_pmt_packet, 0, sizeof( mumudvb_ts_packet_t));//we clear it
 				pthread_mutex_init(&chan_p->channels[ichan].scam_pmt_packet->packetmutex, NULL);
-			} 
+			}
 			// need to send the new PMT to Oscam
 			else if(chan_p->channels[ichan].need_scam_ask==CAM_ASKED)
 				chan_p->channels[ichan].need_scam_ask=CAM_NEED_ASK;
@@ -252,7 +257,6 @@ void chan_update_CAM(mumu_chan_p_t *chan_p, auto_p_t *auto_p,  void *scam_vars_v
 #endif
 	}
 }
-
 
 
 
@@ -298,7 +302,7 @@ void update_chan_net(mumu_chan_p_t *chan_p, auto_p_t *auto_p, multi_p_t *multi_p
 		}
 		// Set the number of unicast clients to zero
         chan_p->channels[ichan].num_clients = 0;
-		
+
 		if(multi_p->multicast)
 		{
 			char number[10];

--- a/src/mumudvb_common.c
+++ b/src/mumudvb_common.c
@@ -46,7 +46,7 @@
 
 static char *log_module="Common: ";
 
-#ifndef HAVE_POLL
+#ifdef _WIN32
 static int poll(struct pollfd *pfd, int n, int milliseconds)
 {
 	struct timeval tv;

--- a/src/mumudvb_common.c
+++ b/src/mumudvb_common.c
@@ -35,8 +35,8 @@
 
 #ifndef _WIN32
 #include <sys/poll.h>
-#endif
 #include <sys/time.h>
+#endif
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
@@ -315,7 +315,7 @@ void mumu_free_string(mumu_string_t *string)
 
 /** @brief return the time (in usec) elapsed between the two last calls of this function.
  */
-long int mumu_timing()
+long int mumu_timing(void)
 {
 	static int started=0;
 	static struct timeval oldtime;
@@ -338,9 +338,21 @@ long int mumu_timing()
 /** @brief getting current system time (in usec).
  */
 uint64_t get_time(void) {
+#ifndef _WIN32
 	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	return (ts.tv_sec * 1000000ll + ts.tv_nsec / 1000);
+#else
+	FILETIME ft;
+	GetSystemTimeAsFileTime(&ft);
+	uint64_t tt = ft.dwHighDateTime;
+	tt <<= 32;
+	tt |= ft.dwLowDateTime;
+	tt /= 10;
+	tt -= 11644473600000000ULL;
+
+	return tt;
+#endif
 }
 /** @brief function for buffering demultiplexed data.
  */
@@ -478,7 +490,7 @@ int set_interrupted(int value)
 	return value;
 }
 
-int get_interrupted()
+int get_interrupted(void)
 {
 	int ret;
 	pthread_mutex_lock(&interrupted_mutex);

--- a/src/mumudvb_common.c
+++ b/src/mumudvb_common.c
@@ -24,8 +24,7 @@
  *
  */
 
-
-
+#define _CRT_SECURE_NO_WARNINGS
 
 #include "mumudvb.h"
 #include "log.h"
@@ -52,7 +51,8 @@ static int poll(struct pollfd *pfd, int n, int milliseconds)
 {
 	struct timeval tv;
 	fd_set set;
-	int i, result, maxfd = 0;
+	int i, result;
+	SOCKET maxfd = 0;
 
 	tv.tv_sec = milliseconds / 1000;
 	tv.tv_usec = (milliseconds % 1000) * 1000;

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -14,17 +14,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <sys/time.h>
 #ifndef _WIN32
+#include <sys/time.h>
 #include <sys/poll.h>
 #include <sys/stat.h>
 #include <resolv.h>
 #include <syslog.h>
 #include <sys/mman.h>
+#include <unistd.h>
 #endif
 #include <stdint.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <signal.h>
 #ifdef ANDROID
 #include <limits.h>
@@ -225,7 +225,7 @@ int mumudvb_close(int no_daemon,
 	struct timespec ts;
 #endif
 
-	if(*signalpowerthread)
+	if(!pthread_equal(*signalpowerthread, pthread_self()))
 	{
 		log_message(log_module,MSG_DEBUG,"Signal/power Thread closing\n");
 		*strengththreadshutdown=1;
@@ -248,7 +248,7 @@ int mumudvb_close(int no_daemon,
 		pthread_cond_destroy(&cardthreadparams->threadcond);
 	}
 	//We shutdown the monitoring thread
-	if(*monitorthread)
+	if(!pthread_equal(*monitorthread, pthread_self()))
 	{
 		log_message(log_module,MSG_DEBUG,"Monitor Thread closing\n");
 		monitor_thread_params->threadshutdown=1;

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -297,6 +297,10 @@ int mumudvb_close(int no_daemon,
 	// we close the file descriptors
 	close_card_fd(fds);
 
+	/* we close the udp input socket */
+	if (fds->fd_source > 0)
+		close(fds->fd_source);
+
 	//We close the unicast connections and free the clients
 	unicast_freeing(unicast_vars);
 

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -7,6 +7,7 @@
 
 #define _GNU_SOURCE		//in order to use program_invocation_short_name and pthread_timedjoin_np
 #define _POSIX
+#define _CRT_SECURE_NO_WARNINGS
 
 #include "config.h"
 

--- a/src/network.c
+++ b/src/network.c
@@ -37,8 +37,8 @@
 #include "log.h"
 #ifndef _WIN32
 #include <net/if.h>
-#endif
 #include <unistd.h>
+#endif
 
 
 static char *log_module="Network: ";

--- a/src/network.c
+++ b/src/network.c
@@ -29,6 +29,8 @@
  * @brief Networking functions
  */
 
+#define _CRT_SECURE_NO_WARNINGS
+
 #include "network.h"
 #include "errors.h"
 #include <string.h>

--- a/src/network.c
+++ b/src/network.c
@@ -104,7 +104,7 @@ makesocket (char *szAddr, unsigned short port, int TTL, char *iface, struct sock
 		return -1;
 	}
 
-	iRet = setsockopt (iSocket, SOL_SOCKET, SO_REUSEADDR, &iReuse, sizeof (int));
+	iRet = setsockopt (iSocket, SOL_SOCKET, SO_REUSEADDR, (const char *)&iReuse, sizeof(int));
 	if (iRet < 0)
 	{
 		log_message( log_module,  MSG_ERROR,"setsockopt SO_REUSEADDR failed : %s\n",strerror(errno));
@@ -113,8 +113,7 @@ makesocket (char *szAddr, unsigned short port, int TTL, char *iface, struct sock
 		return -1;
 	}
 
-	iRet =
-			setsockopt (iSocket, IPPROTO_IP, IP_MULTICAST_TTL, &TTL, sizeof (int));
+    iRet = setsockopt(iSocket, IPPROTO_IP, IP_MULTICAST_TTL, (const char *)&TTL, sizeof(int));
 	if (iRet < 0)
 	{
 		log_message( log_module,  MSG_ERROR,"setsockopt IP_MULTICAST_TTL failed.  multicast in kernel? error : %s \n",strerror(errno));
@@ -123,8 +122,7 @@ makesocket (char *szAddr, unsigned short port, int TTL, char *iface, struct sock
 		return -1;
 	}
 
-	iRet = setsockopt (iSocket, IPPROTO_IP, IP_MULTICAST_LOOP,
-			&iLoop, sizeof (int));
+    iRet = setsockopt(iSocket, IPPROTO_IP, IP_MULTICAST_LOOP, (const char *)&iLoop, sizeof(int));
 	if (iRet < 0)
 	{
 		log_message( log_module,  MSG_ERROR,"setsockopt IP_MULTICAST_LOOP failed.  multicast in kernel? error : %s\n",strerror(errno));
@@ -149,7 +147,7 @@ makesocket (char *szAddr, unsigned short port, int TTL, char *iface, struct sock
 			iface_struct.imr_address.s_addr=INADDR_ANY;
 			iface_struct.imr_ifindex=iface_index;
 #endif
-			iRet = setsockopt (iSocket, IPPROTO_IP, IP_MULTICAST_IF, &iface_struct, sizeof (iface_struct));
+            iRet = setsockopt(iSocket, IPPROTO_IP, IP_MULTICAST_IF, (const char *)&iface_struct, sizeof(iface_struct));
 			if (iRet < 0)
 			{
 				log_message( log_module,  MSG_ERROR,"setsockopt IP_MULTICAST_IF failed.  multicast in kernel? error : %s \n",strerror(errno));
@@ -196,7 +194,7 @@ makesocket6 (char *szAddr, unsigned short port, int TTL, char *iface, struct soc
 		return -1;
 	}
 
-	iRet = setsockopt (iSocket, SOL_SOCKET, SO_REUSEADDR, &iReuse, sizeof (int));
+    iRet = setsockopt(iSocket, SOL_SOCKET, SO_REUSEADDR, (const char *)&iReuse, sizeof(int));
 	if (iRet < 0)
 	{
 		log_message( log_module,  MSG_ERROR,"setsockopt SO_REUSEADDR failed : %s\n",strerror(errno));
@@ -204,8 +202,7 @@ makesocket6 (char *szAddr, unsigned short port, int TTL, char *iface, struct soc
 		close(iSocket);
 		return -1;
 	}
-	iRet =
-			setsockopt (iSocket, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &TTL, sizeof (int));
+    iRet = setsockopt(iSocket, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (const char *)&TTL, sizeof(int));
 	if (iRet < 0)
 	{
 		log_message( log_module,  MSG_ERROR,"setsockopt IPV6_MULTICAST_HOPS failed.  multicast in kernel? error : %s \n",strerror(errno));
@@ -220,7 +217,7 @@ makesocket6 (char *szAddr, unsigned short port, int TTL, char *iface, struct soc
 		if(iface_index)
 		{
 			log_message( log_module,  MSG_DEBUG, "Setting IPv6 multicast iface to %s, index %d",iface,iface_index);
-			iRet = setsockopt (iSocket, IPPROTO_IPV6, IPV6_MULTICAST_IF, &iface_index, sizeof (int));
+            iRet = setsockopt(iSocket, IPPROTO_IPV6, IPV6_MULTICAST_IF, (const char *)&iface_index, sizeof(int));
 			if (iRet < 0)
 			{
 				log_message( log_module,  MSG_ERROR,"setsockopt IPV6_MULTICAST_IF failed.  multicast in kernel? error : %s \n",strerror(errno));
@@ -273,7 +270,7 @@ makeclientsocket (char *szAddr, unsigned short port, int TTL, char *iface, struc
 		else
 			blub.imr_ifindex = 0;
 #endif
-		if (setsockopt (socket, IPPROTO_IP, IP_ADD_MEMBERSHIP, &blub, sizeof (blub)))
+        if (setsockopt(socket, IPPROTO_IP, IP_ADD_MEMBERSHIP, (const char *)&blub, sizeof(blub)))
 		{
 			log_message( log_module,  MSG_ERROR, "setsockopt IP_ADD_MEMBERSHIP ipv4 failed (multicast kernel?) : %s\n", strerror(errno));
 			set_interrupted(ERROR_NETWORK<<8);
@@ -316,7 +313,7 @@ makeclientsocket6 (char *szAddr, unsigned short port, int TTL, char *iface,
 	}
 
 	//join the group
-	iRet=inet_pton (AF_INET6, szAddr,&blub.ipv6mr_multiaddr);
+    iRet = inet_pton(AF_INET6, szAddr, &blub.ipv6mr_multiaddr);
 	if (iRet != 1)
 	{
 		log_message( log_module,  MSG_ERROR,"inet_pton failed : %s\n", strerror(errno));
@@ -329,8 +326,7 @@ makeclientsocket6 (char *szAddr, unsigned short port, int TTL, char *iface,
 		blub.ipv6mr_interface=if_nametoindex(iface);
 	else
 		blub.ipv6mr_interface = 0;
-	if (setsockopt
-			(socket, IPPROTO_IPV6, IPV6_JOIN_GROUP, &blub, sizeof (blub)))
+    if (setsockopt(socket, IPPROTO_IPV6, IPV6_JOIN_GROUP, (const char *)&blub, sizeof(blub)))
 	{
 		log_message( log_module,  MSG_ERROR, "setsockopt IPV6_JOIN_GROUP (ipv6) failed (multicast kernel?) : %s\n", strerror(errno));
 		set_interrupted(ERROR_NETWORK<<8);
@@ -367,7 +363,7 @@ makeTCPclientsocket (char *szAddr, unsigned short port,
 		return -1;
 	}
 
-	iRet = setsockopt (iSocket, SOL_SOCKET, SO_REUSEADDR, &iLoop, sizeof (int));
+    iRet = setsockopt(iSocket, SOL_SOCKET, SO_REUSEADDR, (const char *)&iLoop, sizeof(int));
 	if (iRet < 0)
 	{
 		log_message( log_module,  MSG_ERROR,"setsockopt SO_REUSEADDR failed : %s\n", strerror(errno));

--- a/src/network.h
+++ b/src/network.h
@@ -38,6 +38,7 @@
 #include <Iphlpapi.h>
 #include <Ws2def.h>
 #include <ws2ipdef.h>
+#include <netioapi.h>
 #else
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/src/network.h
+++ b/src/network.h
@@ -59,11 +59,12 @@
 int makeclientsocket (char *szAddr, unsigned short port, int TTL, char *iface, struct sockaddr_in *sSockAddr);
 void sendudp (int fd, struct sockaddr_in *sSockAddr, unsigned char *data, int len);
 int makesocket (char *szAddr, unsigned short port, int TTL, char *iface, struct sockaddr_in *sSockAddr);
-int makeTCPclientsocket (char *szAddr, unsigned short port, struct sockaddr_in *sSockAddr);
+int makeTCPclientsocket(char *szAddr, unsigned short port);
 int makeclientsocket6 (char *szAddr, unsigned short port, int TTL, char *iface, struct sockaddr_in6 *sSockAddr);
 void sendudp6 (int fd, struct sockaddr_in6 *sSockAddr, unsigned char *data, int len);
 int makesocket6 (char *szAddr, unsigned short port, int TTL, char *iface, struct sockaddr_in6 *sSockAddr);
+int socket_to_string(int sock, char *pDest, size_t len);
+int socket_to_string_port(int sock, char *pDestAddr, size_t destLen, char *pDestPort, size_t portLen);
+int sockaddr_to_string(struct sockaddr_storage *sa, char *pDest, size_t len);
 
 #endif
-
-

--- a/src/network.h
+++ b/src/network.h
@@ -66,5 +66,7 @@ int makesocket6 (char *szAddr, unsigned short port, int TTL, char *iface, struct
 int socket_to_string(int sock, char *pDest, size_t len);
 int socket_to_string_port(int sock, char *pDestAddr, size_t destLen, char *pDestPort, size_t portLen);
 int sockaddr_to_string(struct sockaddr_storage *sa, char *pDest, size_t len);
+int is_multicast(struct sockaddr_storage *sa);
+int makeUDPclientsocket(char *szAddr, unsigned short port);
 
 #endif

--- a/src/network.h
+++ b/src/network.h
@@ -37,7 +37,6 @@
 #include <Ntddndis.h>
 #include <Iphlpapi.h>
 #include <Ws2def.h>
-#include <ws2ipdef.h>
 #include <netioapi.h>
 #else
 #include <sys/socket.h>

--- a/src/network.h
+++ b/src/network.h
@@ -1,27 +1,27 @@
-/* 
+/*
  * mumudvb - UDP-ize a DVB transport stream.
  * Based on dvbstream by (C) Dave Chapman <dave@dchapman.com> 2001, 2002.
- * 
+ *
  * (C) 2004-2009 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net/
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *     
+ *
  */
 
 /**@file
@@ -31,12 +31,23 @@
 #ifndef _NETWORK_H
 #define _NETWORK_H
 
+#ifdef _WIN32
+#include <WinSock2.h>
+#include <ws2tcpip.h>
+#include <Ntddndis.h>
+#include <Iphlpapi.h>
+#include <Ws2def.h>
+#include <ws2ipdef.h>
+#else
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
-#include <sys/types.h>
 #include <arpa/inet.h>
+#endif
+#include <sys/types.h>
+#ifndef _WIN32
 #include <syslog.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/rewrite.c
+++ b/src/rewrite.c
@@ -1,22 +1,22 @@
-/* 
+/*
  * MuMuDVB - Stream a DVB transport stream.
- * 
+ *
  * (C) 2004-2010 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -26,6 +26,8 @@
 /**@file
  * @brief This file contains the general functions for rewriting
  */
+
+#define _CRT_SECURE_NO_WARNINGS
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/rewrite_eit.c
+++ b/src/rewrite_eit.c
@@ -30,6 +30,8 @@
  * It avoids to have ghost channels which can disturb the clients
  */
 
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -40,10 +42,7 @@
 #include "log.h"
 #include <stdint.h>
 
-
-
 static char *log_module="EIT rewrite: ";
-
 
 /** @brief Display the contents of the EIT table
  *

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -29,7 +29,9 @@
 
 #include "mumudvb.h"
 #include <time.h>
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 /**@brief : This function add the RTP header to a channel
  *

--- a/src/sap.c
+++ b/src/sap.c
@@ -218,7 +218,7 @@ int init_sap(sap_p_t *sap_p, multi_p_t multi_p)
 
 
 /** @brief Send the sap message
- * 
+ *
  * @param sap_p the sap variables
  * @param num_messages the number of sap messages
  */
@@ -257,7 +257,7 @@ int sap_update(mumudvb_channel_t *channel, sap_p_t *sap_p, int curr_channel, mul
 
 	struct in_addr ip_struct4;
 	struct sockaddr_in6 ip_struct6;
-	in_addr_t ip4;
+	uint32_t ip4;
 	struct in6_addr ip6;
 	mumudvb_sap_message_t *sap_message4=NULL;
 	mumudvb_sap_message_t *sap_message6=NULL;
@@ -291,7 +291,7 @@ int sap_update(mumudvb_channel_t *channel, sap_p_t *sap_p, int curr_channel, mul
 
 	if(channel->socketOut4)
 	{
-		if( inet_aton(sap_p->sap_sending_ip4, &ip_struct4))
+		if (inet_pton(AF_INET, sap_p->sap_sending_ip4, &ip_struct4))
 		{
 			ip4=ip_struct4.s_addr;
 			/* Bytes 4-7 (or 4-19) byte: Originating source */
@@ -501,9 +501,8 @@ int sap_add_program(mumudvb_channel_t *channel, sap_p_t *sap_p, mumudvb_sap_mess
 	if(channel->socketOut4)
 	{
 		struct in_addr ip_struct4;
-		if( inet_aton(sap_p->sap_sending_ip4, &ip_struct4) && ip_struct4.s_addr)
-			mumu_string_append(&payload4,
-					"a=source-filter: incl IN IP4 %s %s\r\n", channel->ip4Out, sap_p->sap_sending_ip4);
+		if (inet_pton(AF_INET, sap_p->sap_sending_ip4, &ip_struct4) && ip_struct4.s_addr)
+			mumu_string_append(&payload4, "a=source-filter: incl IN IP4 %s %s\r\n", channel->ip4Out, sap_p->sap_sending_ip4);
 	}
 	if(channel->socketOut6)
 	{
@@ -511,7 +510,7 @@ int sap_add_program(mumudvb_channel_t *channel, sap_p_t *sap_p, mumudvb_sap_mess
 		if( inet_pton(AF_INET6, sap_p->sap_sending_ip6, &ip_struct6))
 		{
 			//ugly way to test non zero ipv6 addr but I didn found a better one
-			u_int8_t  *s6;
+			uint8_t *s6;
 			s6=ip_struct6.sin6_addr.s6_addr;
 			if(s6[0]||s6[1]||s6[2]||s6[3]||s6[4]||s6[5]||s6[6]||s6[7]||s6[8]||s6[9]||s6[10]||s6[11]||s6[12]||s6[13]||s6[14]||s6[15])
 				mumu_string_append(&payload6,
@@ -546,11 +545,11 @@ int sap_add_program(mumudvb_channel_t *channel, sap_p_t *sap_p, mumudvb_sap_mess
 
      Without RTP
 
-     m=video channel_port udp 33     
+     m=video channel_port udp 33
 
-     With RTP 
+     With RTP
 
-     m=video channel_port rtp/avp 33     
+     m=video channel_port rtp/avp 33
 
 	 */
 	if(!multi_p.rtp_header)

--- a/src/sap.c
+++ b/src/sap.c
@@ -28,6 +28,8 @@
  * @date 2008-2013
  */
 
+#define _CRT_SECURE_NO_WARNINGS
+
 #include "sap.h"
 #include "network.h"
 #include <string.h>

--- a/src/ts.c
+++ b/src/ts.c
@@ -568,7 +568,7 @@ unsigned char *get_ts_begin(unsigned char *buf)
 /** @brief compare the SERVICE_ID contained in the channel and in the PMT
  *
  * Return 1 if match or no service_id info, 0 otherwise
- * 
+ *
  * @param pmt the pmt packet
  * @param channel the channel to be checked
  */
@@ -673,14 +673,14 @@ void ts_display_pat(char* log_module,unsigned char *buf)
 
 
 typedef struct {
-	u_char descriptor_tag                         :8;
-	u_char descriptor_length                      :8;
-#if BYTE_ORDER == BIG_ENDIAN
-	u_char country_availability_flag              :1;
-	u_char                                        :7;
+	uint8_t descriptor_tag                         :8;
+	uint8_t descriptor_length                      :8;
+#ifdef __BIG_ENDIAN__
+	uint8_t country_availability_flag              :1;
+	uint8_t                                        :7;
 #else
-	u_char                                        :7;
-	u_char country_availability_flag              :1;
+	uint8_t                                        :7;
+	uint8_t country_availability_flag              :1;
 #endif
 } country_avaibility_descr_t;
 

--- a/src/ts.h
+++ b/src/ts.h
@@ -1,22 +1,22 @@
-/* 
+/*
  * MuMuDVB - Stream a DVB transport stream.
- * 
+ *
  * (C) 2004-2011 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net/
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -33,7 +33,9 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <pthread.h>
+#ifndef _WIN32
 #include <endian.h>
+#endif
 
 #include "config.h"
 
@@ -76,48 +78,48 @@
 
 /** @brief Program Association Table (PAT):*/
 typedef struct {
-   u_char table_id                               :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char section_syntax_indicator               :1;
-   u_char dummy                                  :1;        // has to be 0
-   u_char                                        :2;
-   u_char section_length_hi                      :4;
+   uint8_t table_id                               :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t section_syntax_indicator               :1;
+   uint8_t dummy                                  :1;        // has to be 0
+   uint8_t                                        :2;
+   uint8_t section_length_hi                      :4;
 #else
-   u_char section_length_hi                      :4;
-   u_char                                        :2;
-   u_char dummy                                  :1;        // has to be 0
-   u_char section_syntax_indicator               :1;
+   uint8_t section_length_hi                      :4;
+   uint8_t                                        :2;
+   uint8_t dummy                                  :1;        // has to be 0
+   uint8_t section_syntax_indicator               :1;
 #endif
-   u_char section_length_lo                      :8;
-   u_char transport_stream_id_hi                 :8;
-   u_char transport_stream_id_lo                 :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :2;
-   u_char version_number                         :5;
-   u_char current_next_indicator                 :1;
+   uint8_t section_length_lo                      :8;
+   uint8_t transport_stream_id_hi                 :8;
+   uint8_t transport_stream_id_lo                 :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :2;
+   uint8_t version_number                         :5;
+   uint8_t current_next_indicator                 :1;
 #else
-   u_char current_next_indicator                 :1;
-   u_char version_number                         :5;
-   u_char                                        :2;
+   uint8_t current_next_indicator                 :1;
+   uint8_t version_number                         :5;
+   uint8_t                                        :2;
 #endif
-   u_char section_number                         :8;
-   u_char last_section_number                    :8;
+   uint8_t section_number                         :8;
+   uint8_t last_section_number                    :8;
 } pat_t;
 
 #define PAT_PROG_LEN 4
 
 /** @brief Program Association Table (PAT): program*/
 typedef struct {
-   u_char program_number_hi                      :8;
-   u_char program_number_lo                      :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :3;
-   u_char network_pid_hi                         :5;
+   uint8_t program_number_hi                      :8;
+   uint8_t program_number_lo                      :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :3;
+   uint8_t network_pid_hi                         :5;
 #else
-   u_char network_pid_hi                         :5;
-   u_char                                        :3;
+   uint8_t network_pid_hi                         :5;
+   uint8_t                                        :3;
 #endif
-   u_char network_pid_lo                         :8; 
+   uint8_t network_pid_lo                         :8;
    /* or program_map_pid (if prog_num=0)*/
 } pat_prog_t;
 
@@ -133,58 +135,58 @@ typedef struct {
 
 /** @brief Conditional Access Table (CAT):*/
 typedef struct {
-    u_char table_id                               :8;
-#if BYTE_ORDER == BIG_ENDIAN
-    u_char section_syntax_indicator               :1;
-   u_char dummy                                  :1;        // has to be 0
-   u_char                                        :2;
-   u_char section_length_hi                      :4;
+    uint8_t table_id                               :8;
+#ifdef __BIG_ENDIAN__
+    uint8_t section_syntax_indicator               :1;
+   uint8_t dummy                                  :1;        // has to be 0
+   uint8_t                                        :2;
+   uint8_t section_length_hi                      :4;
 #else
-    u_char section_length_hi                      :4;
-    u_char                                        :2;
-    u_char dummy                                  :1;        // has to be 0
-    u_char section_syntax_indicator               :1;
+    uint8_t section_length_hi                      :4;
+    uint8_t                                        :2;
+    uint8_t dummy                                  :1;        // has to be 0
+    uint8_t section_syntax_indicator               :1;
 #endif
-    u_char section_length_lo                      :8;
-    u_char transport_stream_id_hi                 :8;
-    u_char transport_stream_id_lo                 :8;
-#if BYTE_ORDER == BIG_ENDIAN
-    u_char                                        :2;
-    u_char version_number                         :5;
-    u_char current_next_indicator                 :1;
+    uint8_t section_length_lo                      :8;
+    uint8_t transport_stream_id_hi                 :8;
+    uint8_t transport_stream_id_lo                 :8;
+#ifdef __BIG_ENDIAN__
+    uint8_t                                        :2;
+    uint8_t version_number                         :5;
+    uint8_t current_next_indicator                 :1;
 #else
-    u_char current_next_indicator                 :1;
-    u_char version_number                         :5;
-    u_char                                        :2;
+    uint8_t current_next_indicator                 :1;
+    uint8_t version_number                         :5;
+    uint8_t                                        :2;
 #endif
-    u_char section_number                         :8;
-    u_char last_section_number                    :8;
+    uint8_t section_number                         :8;
+    uint8_t last_section_number                    :8;
 } cat_t;
 
 //Used to generate the CA_PMT message and for autoconfiguration
 /** @brief Mpeg2-TS header*/
 typedef struct {
-  u_char sync_byte                              :8;
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char transport_error_indicator              :1;
-  u_char payload_unit_start_indicator           :1;
-  u_char transport_priority                     :1;
-  u_char pid_hi                                 :5;
+  uint8_t sync_byte                              :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t transport_error_indicator              :1;
+  uint8_t payload_unit_start_indicator           :1;
+  uint8_t transport_priority                     :1;
+  uint8_t pid_hi                                 :5;
 #else
-  u_char pid_hi                                 :5;
-  u_char transport_priority                     :1;
-  u_char payload_unit_start_indicator           :1;
-  u_char transport_error_indicator              :1;
+  uint8_t pid_hi                                 :5;
+  uint8_t transport_priority                     :1;
+  uint8_t payload_unit_start_indicator           :1;
+  uint8_t transport_error_indicator              :1;
 #endif
-  u_char pid_lo                                 :8;
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char transport_scrambling_control           :2;
-  u_char adaptation_field_control               :2;
-  u_char continuity_counter                     :4;
+  uint8_t pid_lo                                 :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t transport_scrambling_control           :2;
+  uint8_t adaptation_field_control               :2;
+  uint8_t continuity_counter                     :4;
 #else
-  u_char continuity_counter                     :4;
-  u_char adaptation_field_control               :2;
-  u_char transport_scrambling_control           :2;
+  uint8_t continuity_counter                     :4;
+  uint8_t adaptation_field_control               :2;
+  uint8_t transport_scrambling_control           :2;
 #endif
 } ts_header_t;
 
@@ -203,48 +205,48 @@ typedef struct {
  */
 
 typedef struct {
-   u_char table_id                               :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char section_syntax_indicator               :1;
-   u_char dummy                                  :1; // has to be 0
-   u_char                                        :2;
-   u_char section_length_hi                      :4;
+   uint8_t table_id                               :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t section_syntax_indicator               :1;
+   uint8_t dummy                                  :1; // has to be 0
+   uint8_t                                        :2;
+   uint8_t section_length_hi                      :4;
 #else
-   u_char section_length_hi                      :4;
-   u_char                                        :2;
-   u_char dummy                                  :1; // has to be 0
-   u_char section_syntax_indicator               :1;
+   uint8_t section_length_hi                      :4;
+   uint8_t                                        :2;
+   uint8_t dummy                                  :1; // has to be 0
+   uint8_t section_syntax_indicator               :1;
 #endif
-   u_char section_length_lo                      :8;
-   u_char program_number_hi                      :8;
-   u_char program_number_lo                      :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :2;
-   u_char version_number                         :5;
-   u_char current_next_indicator                 :1;
+   uint8_t section_length_lo                      :8;
+   uint8_t program_number_hi                      :8;
+   uint8_t program_number_lo                      :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :2;
+   uint8_t version_number                         :5;
+   uint8_t current_next_indicator                 :1;
 #else
-   u_char current_next_indicator                 :1;
-   u_char version_number                         :5;
-   u_char                                        :2;
+   uint8_t current_next_indicator                 :1;
+   uint8_t version_number                         :5;
+   uint8_t                                        :2;
 #endif
-   u_char section_number                         :8;
-   u_char last_section_number                    :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :3;
-   u_char PCR_PID_hi                             :5;
+   uint8_t section_number                         :8;
+   uint8_t last_section_number                    :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :3;
+   uint8_t PCR_PID_hi                             :5;
 #else
-   u_char PCR_PID_hi                             :5;
-   u_char                                        :3;
+   uint8_t PCR_PID_hi                             :5;
+   uint8_t                                        :3;
 #endif
-   u_char PCR_PID_lo                             :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :4;
-   u_char program_info_length_hi                 :4;
+   uint8_t PCR_PID_lo                             :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :4;
+   uint8_t program_info_length_hi                 :4;
 #else
-   u_char program_info_length_hi                 :4;
-   u_char                                        :4;
+   uint8_t program_info_length_hi                 :4;
+   uint8_t                                        :4;
 #endif
-   u_char program_info_length_lo                 :8;
+   uint8_t program_info_length_lo                 :8;
    //descriptors
 } pmt_t;
 
@@ -252,23 +254,23 @@ typedef struct {
 #define PMT_INFO_LEN 5
 /** @brief  Program Map Table (PMT) : program information section*/
 typedef struct {
-   u_char stream_type                            :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :3;
-   u_char elementary_PID_hi                      :5;
+   uint8_t stream_type                            :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :3;
+   uint8_t elementary_PID_hi                      :5;
 #else
-   u_char elementary_PID_hi                      :5;
-   u_char                                        :3;
+   uint8_t elementary_PID_hi                      :5;
+   uint8_t                                        :3;
 #endif
-   u_char elementary_PID_lo                      :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :4;
-   u_char ES_info_length_hi                      :4;
+   uint8_t elementary_PID_lo                      :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :4;
+   uint8_t ES_info_length_hi                      :4;
 #else
-   u_char ES_info_length_hi                      :4;
-   u_char                                        :4;
+   uint8_t ES_info_length_hi                      :4;
+   uint8_t                                        :4;
 #endif
-   u_char ES_info_length_lo                      :8;
+   uint8_t ES_info_length_lo                      :8;
      // descriptors
 } pmt_info_t;
 
@@ -276,19 +278,19 @@ typedef struct {
 #define DESCR_CA_LEN 6
 /** @brief 0x09 ca_descriptor */
 typedef struct {
-  u_char descriptor_tag                         :8;
-  u_char descriptor_length                      :8;
-  u_char CA_type_hi                             :8;
-  u_char CA_type_lo                             :8;
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char reserved                               :3;
-  u_char CA_PID_hi                              :5;
+  uint8_t descriptor_tag                         :8;
+  uint8_t descriptor_length                      :8;
+  uint8_t CA_type_hi                             :8;
+  uint8_t CA_type_lo                             :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t reserved                               :3;
+  uint8_t CA_PID_hi                              :5;
 #else
-  u_char CA_PID_hi                              :5;
-  u_char reserved                               :3;
+  uint8_t CA_PID_hi                              :5;
+  uint8_t reserved                               :3;
 #endif
-  u_char CA_PID_lo                              :8;
-} descr_ca_t; 
+  uint8_t CA_PID_lo                              :8;
+} descr_ca_t;
 
 
 
@@ -303,33 +305,33 @@ typedef struct {
  *
  */
 typedef struct {
-   u_char table_id                               :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char section_syntax_indicator               :1;
-   u_char                                        :3;
-   u_char section_length_hi                      :4;
+   uint8_t table_id                               :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t section_syntax_indicator               :1;
+   uint8_t                                        :3;
+   uint8_t section_length_hi                      :4;
 #else
-   u_char section_length_hi                      :4;
-   u_char                                        :3;
-   u_char section_syntax_indicator               :1;
+   uint8_t section_length_hi                      :4;
+   uint8_t                                        :3;
+   uint8_t section_syntax_indicator               :1;
 #endif
-   u_char section_length_lo                      :8;
-   u_char transport_stream_id_hi                 :8;
-   u_char transport_stream_id_lo                 :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :2;
-   u_char version_number                         :5;
-   u_char current_next_indicator                 :1;
+   uint8_t section_length_lo                      :8;
+   uint8_t transport_stream_id_hi                 :8;
+   uint8_t transport_stream_id_lo                 :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :2;
+   uint8_t version_number                         :5;
+   uint8_t current_next_indicator                 :1;
 #else
-   u_char current_next_indicator                 :1;
-   u_char version_number                         :5;
-   u_char                                        :2;
+   uint8_t current_next_indicator                 :1;
+   uint8_t version_number                         :5;
+   uint8_t                                        :2;
 #endif
-   u_char section_number                         :8;
-   u_char last_section_number                    :8;
-   u_char original_network_id_hi                 :8;
-   u_char original_network_id_lo                 :8;
-   u_char                                        :8;
+   uint8_t section_number                         :8;
+   uint8_t last_section_number                    :8;
+   uint8_t original_network_id_hi                 :8;
+   uint8_t original_network_id_lo                 :8;
+   uint8_t                                        :8;
 } sdt_t;
 
 #define GetSDTTransportStreamId(x) (HILO(((sdt_t *) x)->transport_stream_id))
@@ -338,30 +340,30 @@ typedef struct {
 #define SDT_DESCR_LEN 5
 /**@brief  Service Description Table (SDT), descriptor */
 typedef struct {
-   u_char service_id_hi                          :8;
-   u_char service_id_lo                          :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :6;
-   u_char eit_schedule_flag                      :1;
-   u_char eit_present_following_flag             :1;
-   u_char running_status                         :3;
-   u_char free_ca_mode                           :1;
-   u_char descriptors_loop_length_hi             :4;
+   uint8_t service_id_hi                          :8;
+   uint8_t service_id_lo                          :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :6;
+   uint8_t eit_schedule_flag                      :1;
+   uint8_t eit_present_following_flag             :1;
+   uint8_t running_status                         :3;
+   uint8_t free_ca_mode                           :1;
+   uint8_t descriptors_loop_length_hi             :4;
 #else
-   u_char eit_present_following_flag             :1;
-   u_char eit_schedule_flag                      :1;
-   u_char                                        :6;
-   u_char descriptors_loop_length_hi             :4;
-   u_char free_ca_mode                           :1;
-   u_char running_status                         :3;
+   uint8_t eit_present_following_flag             :1;
+   uint8_t eit_schedule_flag                      :1;
+   uint8_t                                        :6;
+   uint8_t descriptors_loop_length_hi             :4;
+   uint8_t free_ca_mode                           :1;
+   uint8_t running_status                         :3;
 #endif
-   u_char descriptors_loop_length_lo             :8;
+   uint8_t descriptors_loop_length_lo             :8;
 } sdt_descr_t;
 
 /*
  *
  *    3) Event Information Table (EIT):
- * 
+ *
  *       - the EIT contains data concerning events or programmes such as event
  *         name, start time, duration, etc.; - the use of different descriptors
  *         allows the transmission of different kinds of event information e.g.
@@ -372,61 +374,61 @@ typedef struct {
 #define EIT_LEN 14
 
 typedef struct {
-  u_char table_id                               :8;
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char section_syntax_indicator               :1;
-  u_char                                        :3;
-  u_char section_length_hi                      :4;
+  uint8_t table_id                               :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t section_syntax_indicator               :1;
+  uint8_t                                        :3;
+  uint8_t section_length_hi                      :4;
 #else
-  u_char section_length_hi                      :4;
-  u_char                                        :3;
-  u_char section_syntax_indicator               :1;
+  uint8_t section_length_hi                      :4;
+  uint8_t                                        :3;
+  uint8_t section_syntax_indicator               :1;
 #endif
-  u_char section_length_lo                      :8;
-  u_char service_id_hi                          :8;
-  u_char service_id_lo                          :8;
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char                                        :2;
-  u_char version_number                         :5;
-  u_char current_next_indicator                 :1;
+  uint8_t section_length_lo                      :8;
+  uint8_t service_id_hi                          :8;
+  uint8_t service_id_lo                          :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t                                        :2;
+  uint8_t version_number                         :5;
+  uint8_t current_next_indicator                 :1;
 #else
-  u_char current_next_indicator                 :1;
-  u_char version_number                         :5;
-  u_char                                        :2;
+  uint8_t current_next_indicator                 :1;
+  uint8_t version_number                         :5;
+  uint8_t                                        :2;
 #endif
-  u_char section_number                         :8;
-  u_char last_section_number                    :8;
-  u_char transport_stream_id_hi                 :8;
-  u_char transport_stream_id_lo                 :8;
-  u_char original_network_id_hi                 :8;
-  u_char original_network_id_lo                 :8;
-  u_char segment_last_section_number            :8;
-  u_char segment_last_table_id                  :8;
+  uint8_t section_number                         :8;
+  uint8_t last_section_number                    :8;
+  uint8_t transport_stream_id_hi                 :8;
+  uint8_t transport_stream_id_lo                 :8;
+  uint8_t original_network_id_hi                 :8;
+  uint8_t original_network_id_lo                 :8;
+  uint8_t segment_last_section_number            :8;
+  uint8_t segment_last_table_id                  :8;
 } eit_t;
 
 #define EIT_EVENT_LEN 12
 /**@brief  Event Information Table (EIT), descriptor header*/
 typedef struct {
-   u_char event_id_hi                            :8;
-   u_char event_id_lo                            :8;
-   u_char start_time_0                           :8;
-   u_char start_time_1                           :8;
-   u_char start_time_2                           :8;
-   u_char start_time_3                           :8;
-   u_char start_time_4                           :8;
-   u_char duration_0                             :8;
-   u_char duration_1                             :8;
-   u_char duration_2                             :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char running_status                         :3;
-   u_char free_ca_mode                           :1;
-   u_char descriptors_loop_length_hi             :4;
+   uint8_t event_id_hi                            :8;
+   uint8_t event_id_lo                            :8;
+   uint8_t start_time_0                           :8;
+   uint8_t start_time_1                           :8;
+   uint8_t start_time_2                           :8;
+   uint8_t start_time_3                           :8;
+   uint8_t start_time_4                           :8;
+   uint8_t duration_0                             :8;
+   uint8_t duration_1                             :8;
+   uint8_t duration_2                             :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t running_status                         :3;
+   uint8_t free_ca_mode                           :1;
+   uint8_t descriptors_loop_length_hi             :4;
 #else
-   u_char descriptors_loop_length_hi             :4;
-   u_char free_ca_mode                           :1;
-   u_char running_status                         :3;
+   uint8_t descriptors_loop_length_hi             :4;
+   uint8_t free_ca_mode                           :1;
+   uint8_t running_status                         :3;
 #endif
-   u_char descriptors_loop_length_lo             :8;
+   uint8_t descriptors_loop_length_lo             :8;
 } eit_event_t;
 
 
@@ -444,87 +446,87 @@ typedef struct {
 #define NIT_LEN 10
 
 typedef struct {
-   u_char table_id                               :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char section_syntax_indicator               :1;
-   u_char                                        :3;
-   u_char section_length_hi                      :4;
+   uint8_t table_id                               :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t section_syntax_indicator               :1;
+   uint8_t                                        :3;
+   uint8_t section_length_hi                      :4;
 #else
-   u_char section_length_hi                      :4;
-   u_char                                        :3;
-   u_char section_syntax_indicator               :1;
+   uint8_t section_length_hi                      :4;
+   uint8_t                                        :3;
+   uint8_t section_syntax_indicator               :1;
 #endif
-   u_char section_length_lo                      :8;
-   u_char network_id_hi                          :8;
-   u_char network_id_lo                          :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :2;
-   u_char version_number                         :5;
-   u_char current_next_indicator                 :1;
+   uint8_t section_length_lo                      :8;
+   uint8_t network_id_hi                          :8;
+   uint8_t network_id_lo                          :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :2;
+   uint8_t version_number                         :5;
+   uint8_t current_next_indicator                 :1;
 #else
-   u_char current_next_indicator                 :1;
-   u_char version_number                         :5;
-   u_char                                        :2;
+   uint8_t current_next_indicator                 :1;
+   uint8_t version_number                         :5;
+   uint8_t                                        :2;
 #endif
-   u_char section_number                         :8;
-   u_char last_section_number                    :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :4;
-   u_char network_descriptor_length_hi           :4;
+   uint8_t section_number                         :8;
+   uint8_t last_section_number                    :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :4;
+   uint8_t network_descriptor_length_hi           :4;
 #else
-   u_char network_descriptor_length_hi           :4;
-   u_char                                        :4;
+   uint8_t network_descriptor_length_hi           :4;
+   uint8_t                                        :4;
 #endif
-   u_char network_descriptor_length_lo           :8;
+   uint8_t network_descriptor_length_lo           :8;
   /* descriptors */
 }nit_t;
 
 #define SIZE_NIT_MID 2
 
 typedef struct {                                 // after descriptors
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :4;
-   u_char transport_stream_loop_length_hi        :4;
+#ifdef __BIG_ENDIAN__
+    uint8_t                                        :4;
+    uint8_t transport_stream_loop_length_hi        :4;
 #else
-   u_char transport_stream_loop_length_hi        :4;
-   u_char                                        :4;
+    uint8_t transport_stream_loop_length_hi        :4;
+    uint8_t                                        :4;
 #endif
-   u_char transport_stream_loop_length_lo        :8;
+   uint8_t transport_stream_loop_length_lo        :8;
 }nit_mid_t;
 
 #define NIT_TS_LEN 6
 
 typedef struct {
-   u_char transport_stream_id_hi                 :8;
-   u_char transport_stream_id_lo                 :8;
-   u_char original_network_id_hi                 :8;
-   u_char original_network_id_lo                 :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :4;
-   u_char transport_descriptors_length_hi        :4;
+   uint8_t transport_stream_id_hi                 :8;
+   uint8_t transport_stream_id_lo                 :8;
+   uint8_t original_network_id_hi                 :8;
+   uint8_t original_network_id_lo                 :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :4;
+   uint8_t transport_descriptors_length_hi        :4;
 #else
-   u_char transport_descriptors_length_hi        :4;
-   u_char                                        :4;
+   uint8_t transport_descriptors_length_hi        :4;
+   uint8_t                                        :4;
 #endif
-   u_char transport_descriptors_length_lo        :8;
+   uint8_t transport_descriptors_length_lo        :8;
    /* descriptors  */
 }nit_ts_t;
 
 #define NIT_LCN_LEN 4
 
 typedef struct {
-   u_char service_id_hi                          :8;
-   u_char service_id_lo                          :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char visible_service_flag                   :1;
-   u_char reserved                               :5;
-   u_char logical_channel_number_hi              :2;
+   uint8_t service_id_hi                          :8;
+   uint8_t service_id_lo                          :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t visible_service_flag                   :1;
+   uint8_t reserved                               :5;
+   uint8_t logical_channel_number_hi              :2;
 #else
-   u_char logical_channel_number_hi              :2;
-   u_char reserved                               :5;
-   u_char visible_service_flag                   :1;
+   uint8_t logical_channel_number_hi              :2;
+   uint8_t reserved                               :5;
+   uint8_t visible_service_flag                   :1;
 #endif
-   u_char logical_channel_number_lo              :8;
+   uint8_t logical_channel_number_lo              :8;
 }nit_lcn_t;
 
 
@@ -537,110 +539,110 @@ typedef struct {
  * it's mainly used to get the section length
  */
 typedef struct {
-   u_char table_id                               :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char section_syntax_indicator               :1;
-   u_char                                        :3;
-   u_char section_length_hi                      :4;
+   uint8_t table_id                               :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t section_syntax_indicator               :1;
+   uint8_t                                        :3;
+   uint8_t section_length_hi                      :4;
 #else
-   u_char section_length_hi                      :4;
-   u_char                                        :3;
-   u_char section_syntax_indicator               :1;
+   uint8_t section_length_hi                      :4;
+   uint8_t                                        :3;
+   uint8_t section_syntax_indicator               :1;
 #endif
-   u_char section_length_lo                      :8;
-   u_char transport_stream_id_hi                 :8;
-   u_char transport_stream_id_lo                 :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :2;
-   u_char version_number                         :5;
-   u_char current_next_indicator                 :1;
+   uint8_t section_length_lo                      :8;
+   uint8_t transport_stream_id_hi                 :8;
+   uint8_t transport_stream_id_lo                 :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :2;
+   uint8_t version_number                         :5;
+   uint8_t current_next_indicator                 :1;
 #else
-   u_char current_next_indicator                 :1;
-   u_char version_number                         :5;
-   u_char                                        :2;
+   uint8_t current_next_indicator                 :1;
+   uint8_t version_number                         :5;
+   uint8_t                                        :2;
 #endif
-   u_char section_number                         :8;
-   u_char last_section_number                    :8;
+   uint8_t section_number                         :8;
+   uint8_t last_section_number                    :8;
 } tbl_h_t;
 
 
 
 /** @brief 0x5a terrestrial_delivery_system_descriptor */
 typedef struct {
-  u_char descriptor_tag                         :8;
-  u_char descriptor_length                      :8;
-  u_char frequency_4                            :8;
-  u_char frequency_3                            :8;
-  u_char frequency_2                            :8;
-  u_char frequency_1                            :8;
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char bandwidth                              :3;
-  u_char priority                               :1;
-  u_char Time_Slicing_indicator                 :1;
-  u_char MPE_FEC_indicator                      :1;
-  u_char                                        :2;
+  uint8_t descriptor_tag                         :8;
+  uint8_t descriptor_length                      :8;
+  uint8_t frequency_4                            :8;
+  uint8_t frequency_3                            :8;
+  uint8_t frequency_2                            :8;
+  uint8_t frequency_1                            :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t bandwidth                              :3;
+  uint8_t priority                               :1;
+  uint8_t Time_Slicing_indicator                 :1;
+  uint8_t MPE_FEC_indicator                      :1;
+  uint8_t                                        :2;
 #else
-  u_char                                        :2;
-  u_char MPE_FEC_indicator                      :1;
-  u_char Time_Slicing_indicator                 :1;
-  u_char priority                               :1;
-  u_char bandwidth                              :3;
+  uint8_t                                        :2;
+  uint8_t MPE_FEC_indicator                      :1;
+  uint8_t Time_Slicing_indicator                 :1;
+  uint8_t priority                               :1;
+  uint8_t bandwidth                              :3;
 #endif
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char constellation                          :2;
-  u_char hierarchy_information                  :3;
-  u_char code_rate_HP_stream                    :3;
+#ifdef __BIG_ENDIAN__
+  uint8_t constellation                          :2;
+  uint8_t hierarchy_information                  :3;
+  uint8_t code_rate_HP_stream                    :3;
 #else
-  u_char code_rate_HP_stream                    :3;
-  u_char hierarchy_information                  :3;
-  u_char constellation                          :2;
+  uint8_t code_rate_HP_stream                    :3;
+  uint8_t hierarchy_information                  :3;
+  uint8_t constellation                          :2;
 #endif
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char code_rate_LP_stream                    :3;
-  u_char guard_interval                         :2;
-  u_char transmission_mode                      :2;
-  u_char other_frequency_flag                   :1;
+#ifdef __BIG_ENDIAN__
+  uint8_t code_rate_LP_stream                    :3;
+  uint8_t guard_interval                         :2;
+  uint8_t transmission_mode                      :2;
+  uint8_t other_frequency_flag                   :1;
 #else
-  u_char other_frequency_flag                   :1;
-  u_char transmission_mode                      :2;
-  u_char guard_interval                         :2;
-  u_char code_rate_LP_stream                    :3;
+  uint8_t other_frequency_flag                   :1;
+  uint8_t transmission_mode                      :2;
+  uint8_t guard_interval                         :2;
+  uint8_t code_rate_LP_stream                    :3;
 #endif
 } descr_terr_delivery_t;
 
 
 /** @brief 0x43 satellite_delivery_system_descriptor */
 typedef struct {
-  u_char descriptor_tag                         :8;
-  u_char descriptor_length                      :8;
-  u_char frequency_4                            :8;
-  u_char frequency_3                            :8;
-  u_char frequency_2                            :8;
-  u_char frequency_1                            :8;
-  u_char orbital_position_hi                    :8;
-  u_char orbital_position_lo                    :8;
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char west_east_flag                         :1;
-  u_char polarization	                        :2;
-  u_char roll_off		               			:2;
-  u_char modulation_system                      :1;
-  u_char modulation_type	               		:2;
+  uint8_t descriptor_tag                         :8;
+  uint8_t descriptor_length                      :8;
+  uint8_t frequency_4                            :8;
+  uint8_t frequency_3                            :8;
+  uint8_t frequency_2                            :8;
+  uint8_t frequency_1                            :8;
+  uint8_t orbital_position_hi                    :8;
+  uint8_t orbital_position_lo                    :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t west_east_flag                         :1;
+  uint8_t polarization	                        :2;
+  uint8_t roll_off		               			:2;
+  uint8_t modulation_system                      :1;
+  uint8_t modulation_type	               		:2;
 #else
-  u_char modulation_type	               		:2;
-  u_char modulation_system                      :1;
-  u_char roll_off		               			:2;
-  u_char polarization	                        :2;
-  u_char west_east_flag                         :1;
+  uint8_t modulation_type	               		:2;
+  uint8_t modulation_system                      :1;
+  uint8_t roll_off		               			:2;
+  uint8_t polarization	                        :2;
+  uint8_t west_east_flag                         :1;
 #endif
-  u_char symbol_rate_12		               		:8;
-  u_char symbol_rate_34		               		:8;
-  u_char symbol_rate_56		               		:8;
-#if BYTE_ORDER == BIG_ENDIAN
-  u_char symbol_rate_7		               		:4;
-  u_char FEC_inner								:4;
+  uint8_t symbol_rate_12		               		:8;
+  uint8_t symbol_rate_34		               		:8;
+  uint8_t symbol_rate_56		               		:8;
+#ifdef __BIG_ENDIAN__
+  uint8_t symbol_rate_7		               		:4;
+  uint8_t FEC_inner								:4;
 #else
-  u_char FEC_inner								:4;
-  u_char symbol_rate_7		               		:4;
+  uint8_t FEC_inner								:4;
+  uint8_t symbol_rate_7		               		:4;
 #endif
 } descr_sat_delivery_t;
 
@@ -657,34 +659,34 @@ typedef struct {
 
 /**@brief Header of an ATSC PSIP (Program and System Information Protocol) table*/
 typedef struct {
-   u_char table_id                               :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char section_syntax_indicator               :1;
-   u_char private_indicator                      :1;
-   u_char                                        :2;
-   u_char section_length_hi                      :4;
+   uint8_t table_id                               :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t section_syntax_indicator               :1;
+   uint8_t private_indicator                      :1;
+   uint8_t                                        :2;
+   uint8_t section_length_hi                      :4;
 #else
-   u_char section_length_hi                      :4;
-   u_char                                        :2;
-   u_char private_indicator                      :1;
-   u_char section_syntax_indicator               :1;
+   uint8_t section_length_hi                      :4;
+   uint8_t                                        :2;
+   uint8_t private_indicator                      :1;
+   uint8_t section_syntax_indicator               :1;
 #endif
-   u_char section_length_lo                      :8;
-   u_char transport_stream_id_hi                 :8;
-   u_char transport_stream_id_lo                 :8;
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :2;
-   u_char version_number                         :5;
-   u_char current_next_indicator                 :1;
+   uint8_t section_length_lo                      :8;
+   uint8_t transport_stream_id_hi                 :8;
+   uint8_t transport_stream_id_lo                 :8;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :2;
+   uint8_t version_number                         :5;
+   uint8_t current_next_indicator                 :1;
 #else
-   u_char current_next_indicator                 :1;
-   u_char version_number                         :5;
-   u_char                                        :2;
+   uint8_t current_next_indicator                 :1;
+   uint8_t version_number                         :5;
+   uint8_t                                        :2;
 #endif
-   u_char section_number                         :8;
-   u_char last_section_number                    :8;
-   u_char protocol_version                       :8;
-// u_char num_channels_in_section                :8; //For information, in case of TVCT or CVCT
+   uint8_t section_number                         :8;
+   uint8_t last_section_number                    :8;
+   uint8_t protocol_version                       :8;
+// uint8_t num_channels_in_section                :8; //For information, in case of TVCT or CVCT
 } psip_t;
 
 
@@ -692,76 +694,76 @@ typedef struct {
 
 /**@brief PSIP (TC)VCT (Terrestrial/Cable Virtual Channel Table) channels descriptors*/
 typedef struct {
-  uint8_t short_name[14];//The channel short name in UTF-16
+   uint8_t short_name[14];//The channel short name in UTF-16
 
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :4; //reserved
-   u_char major_channel_number_hi4               :4;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :4; //reserved
+   uint8_t major_channel_number_hi4               :4;
 #else
-   u_char major_channel_number_hi4               :4;
-   u_char                                        :4; //reserved
-#endif  
+   uint8_t major_channel_number_hi4               :4;
+   uint8_t                                        :4; //reserved
+#endif
 
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char major_channel_number_lo6               :6;
-   u_char minor_channel_number_hi                :2;
+#ifdef __BIG_ENDIAN__
+   uint8_t major_channel_number_lo6               :6;
+   uint8_t minor_channel_number_hi                :2;
 #else
-   u_char minor_channel_number_hi                :2;
-   u_char major_channel_number_lo6               :6;
-#endif  
+   uint8_t minor_channel_number_hi                :2;
+   uint8_t major_channel_number_lo6               :6;
+#endif
 
-   u_char minor_channel_number_lo                :8;
+   uint8_t minor_channel_number_lo                :8;
 
-   u_char modulation_mode                        :8;
+   uint8_t modulation_mode                        :8;
 
-  u_int8_t carrier_frequency[4];
+   uint8_t carrier_frequency[4];
 
-   u_char channel_tsid_hi                        :8;
+   uint8_t channel_tsid_hi                        :8;
 
-   u_char channel_tsid_lo                        :8;
+   uint8_t channel_tsid_lo                        :8;
 
-   u_char program_number_hi                      :8;
+   uint8_t program_number_hi                      :8;
 
-   u_char program_number_lo                      :8;
+   uint8_t program_number_lo                      :8;
 
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char ETM_location                           :2;
-   u_char access_controlled                      :1;
-   u_char hidden                                 :1;
-   u_char path_select                            :1; //Only cable
-   u_char out_of_band                            :1; //Only cable
-   u_char hide_guide                             :1;
-   u_char                                        :1; //reserved
+#ifdef __BIG_ENDIAN__
+   uint8_t ETM_location                           :2;
+   uint8_t access_controlled                      :1;
+   uint8_t hidden                                 :1;
+   uint8_t path_select                            :1; //Only cable
+   uint8_t out_of_band                            :1; //Only cable
+   uint8_t hide_guide                             :1;
+   uint8_t                                        :1; //reserved
 #else
-   u_char                                        :1; //reserved
-   u_char hide_guide                             :1;
-   u_char out_of_band                            :1; //Only cable
-   u_char path_select                            :1; //Only cable
-   u_char hidden                                 :1;
-   u_char access_controlled                      :1;
-   u_char ETM_location                           :2;
-#endif  
+   uint8_t                                        :1; //reserved
+   uint8_t hide_guide                             :1;
+   uint8_t out_of_band                            :1; //Only cable
+   uint8_t path_select                            :1; //Only cable
+   uint8_t hidden                                 :1;
+   uint8_t access_controlled                      :1;
+   uint8_t ETM_location                           :2;
+#endif
 
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :2; //reserved
-   u_char service_type                           :6;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :2; //reserved
+   uint8_t service_type                           :6;
 #else
-   u_char service_type                           :6;
-   u_char                                        :2; //reserved
-#endif  
+   uint8_t service_type                           :6;
+   uint8_t                                        :2; //reserved
+#endif
 
-   u_char source_id_hi                           :8;
+   uint8_t source_id_hi                           :8;
 
-   u_char source_id_lo                           :8;
+   uint8_t source_id_lo                           :8;
 
-#if BYTE_ORDER == BIG_ENDIAN
-   u_char                                        :6;
-   u_char descriptor_length_hi                   :2;
+#ifdef __BIG_ENDIAN__
+   uint8_t                                        :6;
+   uint8_t descriptor_length_hi                   :2;
 #else
-   u_char descriptor_length_hi                   :2;
-   u_char                                        :6;
-#endif  
-   u_char descriptor_length_lo                   :8;
+   uint8_t descriptor_length_hi                   :2;
+   uint8_t                                        :6;
+#endif
+   uint8_t descriptor_length_lo                   :8;
 } psip_vct_channel_t;
 
 //1 for number strings, 3 for language code,1 for number of segments

--- a/src/tune.c
+++ b/src/tune.c
@@ -31,6 +31,8 @@
  * This file contains functions for tuning the card, or displaying signal strength...
  */
 
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/tune.c
+++ b/src/tune.c
@@ -117,12 +117,14 @@ void init_tune_v(tune_p_t *tune_p)
 				.pls_code = 0,
 				.pls_type = PLS_ROOT,
 	#endif
-				.read_file_path = {'\0'}
+				.read_file_path = { '\0', },
+				.source_addr = { '\0', }
 		};
 #else
 	*tune_p = (tune_p_t){
 		.fe_type = FE_QPSK, //sat by default
-		.read_file_path = {'\0'}
+		.read_file_path = { '\0', },
+		.source_addr = { '\0', }
 	};
 #endif
 }
@@ -718,6 +720,20 @@ int read_tuning_configuration(tune_p_t *tuneparams, char *substring)
 		log_message( log_module,  MSG_DEBUG,
 				"Overriding file from which we read the data %s", tuneparams->read_file_path);
 
+	}
+	else if (!strcmp(substring, "source_addr"))
+	{
+		substring = strtok(NULL, CONFIG_FILE_SEPARATOR);
+		if (strlen(substring) > INET6_ADDRSTRLEN) {
+			log_message(log_module, MSG_ERROR, "The IP address %s is too long.\n", substring);
+			exit(ERROR_CONF);
+		}
+		sscanf(substring, "%s\n", tuneparams->source_addr);
+	}
+	else if (!strcmp(substring, "source_port"))
+	{
+		substring = strtok(NULL, CONFIG_FILE_SEPARATOR);
+		tuneparams->source_port = atoi(substring);
 	}
 	else if (!strcmp (substring, "isdbt_layer"))
 	{

--- a/src/tune.c
+++ b/src/tune.c
@@ -38,8 +38,8 @@
 #ifndef _WIN32
 #include <sys/ioctl.h>
 #include <sys/poll.h>
-#endif
 #include <unistd.h>
+#endif
 #include "config.h"
 #include <errno.h>
 #include <string.h>

--- a/src/tune.h
+++ b/src/tune.h
@@ -218,6 +218,9 @@ typedef struct tune_p_t{
 #endif
   /** If we read directly from a file */
   char read_file_path[256];
+  /* If we read from a UDP/multicast source */
+  char source_addr[64];
+  unsigned short source_port;
 #if ISDBT
   //ISDB T
   /** ISDBT */

--- a/src/tune.h
+++ b/src/tune.h
@@ -34,9 +34,20 @@
 #ifndef _TUNE_H
 #define _TUNE_H
 
+#ifndef DISABLE_DVB_API
 #include <linux/dvb/frontend.h>
 #include <linux/dvb/version.h>
-
+#else
+typedef enum fe_status_t
+{
+    FE_HAS_SIGNAL = 0,
+} fe_status_t;
+typedef enum fe_type_t
+{
+	FE_QPSK = 0,
+	FE_ATSC = 1,
+} fe_type_t;
+#endif
 
 /* DVB-S */
 /** lnb_slof: switch frequency of LNB */
@@ -158,13 +169,16 @@ typedef struct tune_p_t{
   int diseqc_time;
   /** The frequency for SCR/unicable */
   uint32_t uni_freq;
+#ifndef DISABLE_DVB_API
   /** The kind of modulation */
   fe_modulation_t modulation;
+#endif
   int modulation_set;
+#ifndef DISABLE_DVB_API
   /** high priority stream code rate ie error correction, FEC */
   fe_code_rate_t HP_CodeRate;
-  /** low priority stream code rate 
-   * In order to achieve hierarchy, two different code rates may be applied to two different levels of the modulation.*/ 
+  /** low priority stream code rate
+   * In order to achieve hierarchy, two different code rates may be applied to two different levels of the modulation.*/
   fe_code_rate_t LP_CodeRate;
   /** For DVB-T */
   fe_transmit_mode_t TransmissionMode;
@@ -172,10 +186,11 @@ typedef struct tune_p_t{
   fe_guard_interval_t guardInterval;
   /**For DVB-T : the bandwith (often 8MHz)*/
   fe_bandwidth_t bandwidth;
-  /**For DVB-T 
+  /**For DVB-T
    It seems that it's related to the capability to transmit information in parallel
   Not configurable for the moment, I have found no transponder to test it*/
   fe_hierarchy_t hier;
+#endif
   /** do we periodically display the strenght of the signal ?*/
   int display_strenght;
   /** do we periodically check the status of the card ?*/
@@ -214,21 +229,16 @@ typedef struct tune_p_t{
   /** ISDBT */
   int isdbt_layer;
 #endif
+#ifndef DISABLE_DVB_API
   /** Spectral inversion */
   fe_spectral_inversion_t inversion;
+#endif
 
-}tune_p_t;
-
-
-
-
+} tune_p_t;
 
 void init_tune_v(tune_p_t *);
 int tune_it(int, tune_p_t *);
 int read_tuning_configuration(tune_p_t *, char *);
 void print_status(fe_status_t festatus);
-
-
-
 
 #endif

--- a/src/unicast_clients.c
+++ b/src/unicast_clients.c
@@ -70,7 +70,7 @@ static char *log_module="Unicast : ";
  * @param SocketAddr The socket address
  * @param Socket The socket number
  */
-unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct sockaddr_in SocketAddr, int Socket)
+unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, int Socket)
 {
 
 	unicast_client_t *client;
@@ -140,7 +140,6 @@ unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct 
 	}
 
 	//We fill the client data
-	client->SocketAddr=SocketAddr;
 	client->Socket=Socket;
 	client->buffer=NULL;
 	client->buffersize=0;
@@ -176,10 +175,10 @@ unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct 
 int unicast_del_client(unicast_parameters_t *unicast_vars, unicast_client_t *client)
 {
 	unicast_client_t *prev_client,*next_client;
-	char addr_buf[64];
+	char addr_buf[IPV6_CHAR_LEN];
 
-	inet_ntop(AF_INET, &client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
-	log_message( log_module, MSG_FLOOD,"We delete the client %s:%d, socket %d\n", addr_buf, client->SocketAddr.sin_port, client->Socket);
+	socket_to_string(client->Socket, addr_buf, sizeof(addr_buf));
+	log_message(log_module, MSG_FLOOD, "We delete the client %s, socket %d\n", addr_buf, client->Socket);
 
 	if (client->Socket >= 0)
 	{
@@ -243,10 +242,10 @@ int channel_add_unicast_client(unicast_client_t *client,mumudvb_channel_t *chann
 {
 	unicast_client_t *last_client;
 	int iRet;
-	char addr_buf[64];
+	char addr_buf[IPV6_CHAR_LEN];
 
-	inet_ntop(AF_INET, &client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
-	log_message( log_module, MSG_INFO,"We add the client %s:%d to the channel \"%s\"\n", addr_buf, client->SocketAddr.sin_port,channel->name);
+	socket_to_string(client->Socket, addr_buf, sizeof(addr_buf));
+	log_message(log_module, MSG_INFO, "We add the client %s to the channel \"%s\"\n", addr_buf, channel->name);
 
     iRet = write(client->Socket, HTTP_OK_REPLY, strlen(HTTP_OK_REPLY));
 	if(iRet!=strlen(HTTP_OK_REPLY))

--- a/src/unicast_clients.c
+++ b/src/unicast_clients.c
@@ -29,12 +29,15 @@
  */
 
 
-
+#ifndef _WIN32
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
-#include <sys/types.h>
 #include <arpa/inet.h>
+#include <sys/ioctl.h>
+#include <netinet/tcp.h>
+#endif
+#include <sys/types.h>
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
@@ -42,10 +45,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
-#include <sys/ioctl.h>
 #include <time.h>
 #include <stdlib.h>
-#include <netinet/tcp.h>
 
 
 #include "unicast_http.h"
@@ -198,7 +199,7 @@ int unicast_del_client(unicast_parameters_t *unicast_vars, unicast_client_t *cli
 		log_message( log_module, MSG_DEBUG,"We remove the client from the channel \"%s\"\n",client->chan_ptr->name);
 		// decrement the number of client connections
         client->chan_ptr->num_clients--;
-		
+
 		if(client->chan_prev==NULL)
 		{
 			client->chan_ptr->clients=client->chan_next;
@@ -249,7 +250,7 @@ int channel_add_unicast_client(unicast_client_t *client,mumudvb_channel_t *chann
 	client->chan_next=NULL;
 	// Increment the number of client connections
     channel->num_clients++;
-	
+
 	if(channel->clients==NULL)
 	{
 		channel->clients=client;

--- a/src/unicast_clients.c
+++ b/src/unicast_clients.c
@@ -36,9 +36,9 @@
 #include <arpa/inet.h>
 #include <sys/ioctl.h>
 #include <netinet/tcp.h>
+#include <unistd.h>
 #endif
 #include <sys/types.h>
-#include <unistd.h>
 #include <errno.h>
 #include <string.h>
 #include <fcntl.h>

--- a/src/unicast_clients.c
+++ b/src/unicast_clients.c
@@ -104,7 +104,7 @@ unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct 
 	// Disable the Nagle (TCP No Delay) algorithm
 	int iRet;
 	int on = 1;
-	iRet=setsockopt(Socket, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on));
+	iRet = setsockopt(Socket, IPPROTO_TCP, TCP_NODELAY, (const char *)&on, sizeof(on));
 	if (iRet < 0)
 	{
 		log_message( log_module,  MSG_WARN,"setsockopt TCP_NODELAY failed : %s\n", strerror(errno));
@@ -112,8 +112,8 @@ unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct 
 
 	int buffer_size;
 	socklen_t size;
-	size=sizeof(buffer_size);
-	iRet=getsockopt( Socket, SOL_SOCKET, SO_SNDBUF, &buffer_size, &size);
+	size = sizeof(buffer_size);
+	iRet = getsockopt(Socket, SOL_SOCKET, SO_SNDBUF, (char *)&buffer_size, &size);
 	if (iRet < 0)
 	{
 		log_message( log_module,  MSG_WARN,"get SO_SNDBUF failed : %s\n", strerror(errno));
@@ -123,15 +123,15 @@ unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct 
 	if(unicast_vars->socket_sendbuf_size)
 	{
 		buffer_size = unicast_vars->socket_sendbuf_size;
-		iRet=setsockopt(Socket, SOL_SOCKET, SO_SNDBUF, &buffer_size, sizeof(buffer_size));
+		iRet = setsockopt(Socket, SOL_SOCKET, SO_SNDBUF, (const char *)&buffer_size, sizeof(buffer_size));
 		if (iRet < 0)
 		{
 			log_message( log_module,  MSG_WARN,"setsockopt SO_SNDBUF failed : %s\n", strerror(errno));
 		}
 		else
 		{
-			size=sizeof(buffer_size);
-			iRet=getsockopt( Socket, SOL_SOCKET, SO_SNDBUF, &buffer_size, &size);
+			size = sizeof(buffer_size);
+			iRet = getsockopt(Socket, SOL_SOCKET, SO_SNDBUF, (char *)&buffer_size, &size);
 			if (iRet < 0)
 				log_message( log_module,  MSG_WARN,"2nd get SO_SNDBUF failed : %s\n", strerror(errno));
 			else
@@ -176,8 +176,10 @@ unicast_client_t *unicast_add_client(unicast_parameters_t *unicast_vars, struct 
 int unicast_del_client(unicast_parameters_t *unicast_vars, unicast_client_t *client)
 {
 	unicast_client_t *prev_client,*next_client;
+	char addr_buf[64];
 
-	log_message( log_module, MSG_FLOOD,"We delete the client %s:%d, socket %d\n",inet_ntoa(client->SocketAddr.sin_addr), client->SocketAddr.sin_port, client->Socket);
+	inet_ntop(AF_INET, &client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+	log_message( log_module, MSG_FLOOD,"We delete the client %s:%d, socket %d\n", addr_buf, client->SocketAddr.sin_port, client->Socket);
 
 	if (client->Socket >= 0)
 	{
@@ -241,10 +243,12 @@ int channel_add_unicast_client(unicast_client_t *client,mumudvb_channel_t *chann
 {
 	unicast_client_t *last_client;
 	int iRet;
+	char addr_buf[64];
 
-	log_message( log_module, MSG_INFO,"We add the client %s:%d to the channel \"%s\"\n",inet_ntoa(client->SocketAddr.sin_addr), client->SocketAddr.sin_port,channel->name);
+	inet_ntop(AF_INET, &client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+	log_message( log_module, MSG_INFO,"We add the client %s:%d to the channel \"%s\"\n", addr_buf, client->SocketAddr.sin_port,channel->name);
 
-	iRet=write(client->Socket,HTTP_OK_REPLY, strlen(HTTP_OK_REPLY));
+    iRet = write(client->Socket, HTTP_OK_REPLY, strlen(HTTP_OK_REPLY));
 	if(iRet!=strlen(HTTP_OK_REPLY))
 	{
 		log_message( log_module, MSG_INFO,"Error when sending the HTTP reply\n");

--- a/src/unicast_clients.c
+++ b/src/unicast_clients.c
@@ -28,6 +28,7 @@
  * @date 2009
  */
 
+#define _CRT_SECURE_NO_WARNINGS
 
 #ifndef _WIN32
 #include <sys/socket.h>

--- a/src/unicast_clients.c
+++ b/src/unicast_clients.c
@@ -38,6 +38,9 @@
 #include <sys/ioctl.h>
 #include <netinet/tcp.h>
 #include <unistd.h>
+#else
+#define write(sock, buf, size) send(sock, buf, size, 0)
+#define close(sock) closesocket(sock)
 #endif
 #include <sys/types.h>
 #include <errno.h>

--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -37,6 +37,9 @@
 #include <netinet/in.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#else
+#define write(sock, buf, size) send(sock, buf, size, 0)
+#define close(sock) closesocket(sock)
 #endif
 #include <sys/types.h>
 #include <errno.h>

--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -30,6 +30,7 @@
 
 //in order to use asprintf (extension gnu)
 #define _GNU_SOURCE
+#define _CRT_SECURE_NO_WARNINGS
 
 #ifndef _WIN32
 #include <sys/socket.h>

--- a/src/unicast_http.c
+++ b/src/unicast_http.c
@@ -38,16 +38,16 @@
 #include <arpa/inet.h>
 #endif
 #include <sys/types.h>
-#include <unistd.h>
 #include <errno.h>
 #include <string.h>
-#include <strings.h>
 #ifndef _WIN32
 #include <poll.h>
+#include <unistd.h>
+#include <strings.h>
+#include <sys/time.h>
 #endif
 #include <fcntl.h>
 #include <stdio.h>
-#include <sys/time.h>
 #include <string.h>
 #include <stdarg.h>
 #include <time.h>
@@ -71,6 +71,10 @@
 #include "scam_common.h"
 #include "scam_getcw.h"
 #include "scam_decsa.h"
+#endif
+
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
 #endif
 
 static char *log_module="Unicast : ";

--- a/src/unicast_http.h
+++ b/src/unicast_http.h
@@ -1,22 +1,22 @@
-/* 
+/*
  * mumudvb - UDP-ize a DVB transport stream.
- * 
+ *
  * (C) 2009 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net/
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -112,8 +112,6 @@ enum
  */
 typedef struct unicast_client_t{
   /**HTTP socket*/
-  struct sockaddr_in SocketAddr;
-  /**HTTP socket*/
   int Socket;
   /**Reception buffer*/
   char *buffer;
@@ -168,7 +166,7 @@ typedef struct unicast_parameters_t{
   /** Do we activate unicast ?*/
   int unicast;
   /**The "HTTP" ip address*/
-  char ipOut[20];
+  char ipOut[INET6_ADDRSTRLEN];
   /** The "HTTP" port*/
   int portOut;
   /** The "HTTP" port string version before parsing*/
@@ -216,7 +214,7 @@ struct unicast_reply {
  int unicast_reply_write(struct unicast_reply *reply, const char* msg, ...);
  int unicast_reply_send(struct unicast_reply *reply, int socket, int code, const char* content_type);
 
-int unicast_create_listening_socket(int socket_type, int socket_channel, char *ipOut, int port, struct sockaddr_in *sIn, int *socketIn, unicast_parameters_t *unicast_vars);
+int unicast_create_listening_socket(int socket_type, int socket_channel, char *ipOut, int port, int *socketIn, unicast_parameters_t *unicast_vars);
 
 struct strength_parameters_t; //just to avoid including dvb.h for one structure
 struct eit_packet_t; //just to avoid including rewrite.h for one structure

--- a/src/unicast_monit.c
+++ b/src/unicast_monit.c
@@ -28,6 +28,7 @@
  * @date 2013
  */
 
+#define _CRT_SECURE_NO_WARNINGS
 
 #include "unicast_http.h"
 #include "unicast_queue.h"
@@ -46,6 +47,10 @@
 #include "scam_common.h"
 #include "scam_getcw.h"
 #include "scam_decsa.h"
+#endif
+
+#ifdef _WIN32
+#include <process.h> /* for getpid() */
 #endif
 
 static char *log_module="Unicast : ";

--- a/src/unicast_monit.c
+++ b/src/unicast_monit.c
@@ -395,6 +395,7 @@ unicast_send_json_state (int number_of_channels, mumudvb_channel_t *channels, in
 
 	// Frontend type
 	char fetype[10]="Unknown";
+#ifndef DISABLE_DVB_API
 	if (strengthparams->tune_p->fe_type==FE_OFDM)
 #ifdef DVBT2
 		if (strengthparams->tune_p->delivery_system==SYS_DVBT2)
@@ -421,9 +422,13 @@ unicast_send_json_state (int number_of_channels, mumudvb_channel_t *channels, in
 		snprintf(fetype,10,"DVB-S");
 #endif
 	}
+#else
+	snprintf(fetype, 10, "File");
+#endif
 	unicast_reply_write(reply, "\t\"frontend_system\" : \"%s\",\n",fetype);
 
 	// Frontend status
+#ifndef DISABLE_DVB_API
 	char SCVYL[6]="-----";
 	if (strengthparams->festatus & FE_HAS_SIGNAL)  SCVYL[0]=83; // S
 	if (strengthparams->festatus & FE_HAS_CARRIER) SCVYL[1]=67; // C
@@ -431,6 +436,9 @@ unicast_send_json_state (int number_of_channels, mumudvb_channel_t *channels, in
 	if (strengthparams->festatus & FE_HAS_SYNC)    SCVYL[3]=89; // Y
 	if (strengthparams->festatus & FE_HAS_LOCK)    SCVYL[4]=76; // L
 	SCVYL[5]=0;
+#else
+	char SCVYL[6] = "SCVYL";
+#endif
 	unicast_reply_write(reply, "\t\"frontend_status\": \"%s\",\n",SCVYL);
 
 	// Frontend signal
@@ -750,6 +758,7 @@ unicast_send_xml_state (int number_of_channels, mumudvb_channel_t *channels, int
 
 	// Frontend type
 	char fetype[10]="Unknown";
+#ifndef DISABLE_DVB_API
 	if (strengthparams->tune_p->fe_type==FE_OFDM)
 #ifdef DVBT2
 		if (strengthparams->tune_p->delivery_system==SYS_DVBT2)
@@ -776,9 +785,13 @@ unicast_send_xml_state (int number_of_channels, mumudvb_channel_t *channels, int
 		snprintf(fetype,10,"DVB-S");
 #endif
 	}
+#else
+	snprintf(fetype, 10, "File");
+#endif
 	unicast_reply_write(reply, "\t<frontend_system><![CDATA[%s]]></frontend_system>\n",fetype);
 
 	// Frontend status
+#ifndef DISABLE_DVB_API
 	char SCVYL[6]="-----";
 	if (strengthparams->festatus & FE_HAS_SIGNAL)  SCVYL[0]=83; // S
 	if (strengthparams->festatus & FE_HAS_CARRIER) SCVYL[1]=67; // C
@@ -786,6 +799,9 @@ unicast_send_xml_state (int number_of_channels, mumudvb_channel_t *channels, int
 	if (strengthparams->festatus & FE_HAS_SYNC)    SCVYL[3]=89; // Y
 	if (strengthparams->festatus & FE_HAS_LOCK)    SCVYL[4]=76; // L
 	SCVYL[5]=0;
+#else
+	char SCVYL[6] = "SCVYL";
+#endif
 	unicast_reply_write(reply, "\t<frontend_status><![CDATA[%s]]></frontend_status>\n",SCVYL);
 
 	// Frontend signal

--- a/src/unicast_monit.c
+++ b/src/unicast_monit.c
@@ -51,6 +51,7 @@
 
 #ifdef _WIN32
 #include <process.h> /* for getpid() */
+#define getpid() _getpid()
 #endif
 
 static char *log_module="Unicast : ";
@@ -61,12 +62,16 @@ static char *log_module="Unicast : ";
 int unicast_send_client_list_js (unicast_client_t *unicast_client, struct unicast_reply *reply)
 {
 	int client = 0;
+	char addr_buf[64] = { 0 };
+
 	while(unicast_client!=NULL)
 	{
+		inet_ntop(AF_INET, &unicast_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
 		unicast_reply_write(reply, "{\t\t\"client_number\": %d, \"socket\": %d, \"remote_address\": \"%s\", \"remote_port\": %d, \"buffer_size\": %d, \"consecutive_errors\":%d, \"first_error_time\":%d, \"last_error_time\":%d },\n",
 							client,
 							unicast_client->Socket,
-							inet_ntoa(unicast_client->SocketAddr.sin_addr),
+							addr_buf,
 							unicast_client->SocketAddr.sin_port,
 							unicast_client->buffersize,
 							unicast_client->consecutive_errors,
@@ -366,7 +371,7 @@ unicast_send_json_state (int number_of_channels, mumudvb_channel_t *channels, in
 
 	// Mumudvb information
 	unicast_reply_write(reply, "\t\"version\" : \"%s\",\n",VERSION);
-	unicast_reply_write(reply, "\t\"pid\" : %d,\n",getpid ());
+	unicast_reply_write(reply, "\t\"pid\" : %d,\n", getpid());
 
 	// Uptime
 	extern long real_start_time;
@@ -593,11 +598,15 @@ unicast_send_prometheus (int number_of_channels, mumudvb_channel_t *channels, in
 int unicast_send_client_list_xml (unicast_client_t *unicast_client, struct unicast_reply *reply)
 {
 	int client = 0;
+	char addr_buf[64] = { 0 };
+
 	while(unicast_client!=NULL)
 	{
+		inet_ntop(AF_INET, &unicast_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
 		unicast_reply_write(reply, "\t\t\t<client number=\"%d\">\n", client);
 		unicast_reply_write(reply, "\t\t\t\t<socket>%d</socket>", unicast_client->Socket);
-		unicast_reply_write(reply, "\t\t\t\t<remote_address><![CDATA[%s]]></remote_address>\n", inet_ntoa(unicast_client->SocketAddr.sin_addr));
+		unicast_reply_write(reply, "\t\t\t\t<remote_address><![CDATA[%s]]></remote_address>\n", addr_buf);
 		unicast_reply_write(reply, "\t\t\t\t<remote_port>%d</remote_port>", unicast_client->SocketAddr.sin_port);
 		unicast_reply_write(reply, "\t\t\t\t<buffersize>%u</buffersize>\n",unicast_client->buffersize);
 		unicast_reply_write(reply, "\t\t\t\t<consecutive_errors>%d</consecutive_errors>\n", unicast_client->consecutive_errors);
@@ -623,10 +632,10 @@ int unicast_send_channel_list_xml (int number_of_channels, mumudvb_channel_t *ch
 {
 
 #ifndef ENABLE_SCAM_SUPPORT
-        (void) scam_vars_v; //to make compiler happy
-		char *scam_vars;
+    (void) scam_vars_v; //to make compiler happy
 #else
-        scam_parameters_t *scam_vars=(scam_parameters_t *)scam_vars_v;
+    char *scam_vars;
+    scam_parameters_t *scam_vars=(scam_parameters_t *)scam_vars_v;
 #endif
 
 	// Channels list
@@ -737,7 +746,7 @@ unicast_send_xml_state (int number_of_channels, mumudvb_channel_t *channels, int
 
 	// Mumudvb information
 	unicast_reply_write(reply, "\t<global_version><![CDATA[%s]]></global_version>\n",VERSION);
-	unicast_reply_write(reply, "\t<global_pid>%d</global_pid>\n",getpid ());
+	unicast_reply_write(reply, "\t<global_pid>%d</global_pid>\n", getpid());
 
 	// Uptime
 	extern long real_start_time;

--- a/src/unicast_monit.c
+++ b/src/unicast_monit.c
@@ -62,17 +62,18 @@ static char *log_module="Unicast : ";
 int unicast_send_client_list_js (unicast_client_t *unicast_client, struct unicast_reply *reply)
 {
 	int client = 0;
-	char addr_buf[64] = { 0 };
+	char addr_buf[IPV6_CHAR_LEN] = { 0, };
+	char port_buf[6] = { 0, };
 
 	while(unicast_client!=NULL)
 	{
-		inet_ntop(AF_INET, &unicast_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+		socket_to_string_port(unicast_client->Socket, addr_buf, sizeof(addr_buf), port_buf, sizeof(port_buf));
 
-		unicast_reply_write(reply, "{\t\t\"client_number\": %d, \"socket\": %d, \"remote_address\": \"%s\", \"remote_port\": %d, \"buffer_size\": %d, \"consecutive_errors\":%d, \"first_error_time\":%d, \"last_error_time\":%d },\n",
+		unicast_reply_write(reply, "{\t\t\"client_number\": %d, \"socket\": %d, \"remote_address\": \"%s\", \"remote_port\": %s, \"buffer_size\": %d, \"consecutive_errors\":%d, \"first_error_time\":%d, \"last_error_time\":%d },\n",
 							client,
 							unicast_client->Socket,
 							addr_buf,
-							unicast_client->SocketAddr.sin_port,
+							port_buf,
 							unicast_client->buffersize,
 							unicast_client->consecutive_errors,
 							unicast_client->first_error_time,
@@ -598,16 +599,17 @@ unicast_send_prometheus (int number_of_channels, mumudvb_channel_t *channels, in
 int unicast_send_client_list_xml (unicast_client_t *unicast_client, struct unicast_reply *reply)
 {
 	int client = 0;
-	char addr_buf[64] = { 0 };
+	char addr_buf[IPV6_CHAR_LEN] = { 0, };
+	char port_buf[6] = { 0, };
 
 	while(unicast_client!=NULL)
 	{
-		inet_ntop(AF_INET, &unicast_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+		socket_to_string_port(unicast_client->Socket, addr_buf, sizeof(addr_buf), port_buf, sizeof(port_buf));
 
 		unicast_reply_write(reply, "\t\t\t<client number=\"%d\">\n", client);
 		unicast_reply_write(reply, "\t\t\t\t<socket>%d</socket>", unicast_client->Socket);
 		unicast_reply_write(reply, "\t\t\t\t<remote_address><![CDATA[%s]]></remote_address>\n", addr_buf);
-		unicast_reply_write(reply, "\t\t\t\t<remote_port>%d</remote_port>", unicast_client->SocketAddr.sin_port);
+		unicast_reply_write(reply, "\t\t\t\t<remote_port>%s</remote_port>", port_buf);
 		unicast_reply_write(reply, "\t\t\t\t<buffersize>%u</buffersize>\n",unicast_client->buffersize);
 		unicast_reply_write(reply, "\t\t\t\t<consecutive_errors>%d</consecutive_errors>\n", unicast_client->consecutive_errors);
 		unicast_reply_write(reply, "\t\t\t\t<first_error_time>%d</first_error_time>\n", unicast_client->first_error_time);

--- a/src/unicast_queue.c
+++ b/src/unicast_queue.c
@@ -1,22 +1,22 @@
-/* 
+/*
  * MuMuDVB - UDP-ize a DVB transport stream.
- * 
+ *
  * (C) 2009 Brice DUBOST
- * 
+ *
  * The latest version can be found at http://mumudvb.net
- * 
+ *
  * Copyright notice:
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -38,6 +38,12 @@
 #include "mumudvb.h"
 #include "errors.h"
 #include "log.h"
+
+#ifdef _WIN32
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL (0)
+#endif
+#endif
 
 static char *log_module="Unicast : ";
 

--- a/src/unicast_queue.c
+++ b/src/unicast_queue.c
@@ -66,6 +66,8 @@ void unicast_close_connection(unicast_parameters_t *unicast_vars, int Socket);
  */
 void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *unicast_vars)
 {
+	char addr_buf[64] = { 0, };
+
 	if(actual_channel->clients)
 	{
 		unicast_client_t *actual_client;
@@ -95,8 +97,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 					if(!actual_client->queue.full)
 					{
 						actual_client->queue.full=1;
-						log_message( log_module, MSG_DETAIL,"The queue is full, we now throw away new packets for client %s:%d\n",
-								inet_ntoa(actual_client->SocketAddr.sin_addr),
+						inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
+						log_message(log_module, MSG_DETAIL, "The queue is full, we now throw away new packets for client %s:%d\n",
+								addr_buf,
 								actual_client->SocketAddr.sin_port);
 					}
 				}
@@ -118,8 +122,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 					{
 						if(errno != actual_client->last_write_error)
 						{
-							log_message( log_module, MSG_DEBUG,"New error when writing to client %s:%d : %s\n",
-									inet_ntoa(actual_client->SocketAddr.sin_addr),
+							inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
+							log_message(log_module, MSG_DEBUG, "New error when writing to client %s:%d : %s\n",
+									addr_buf,
 									actual_client->SocketAddr.sin_port,
 									strerror(errno));
 							actual_client->last_write_error=errno;
@@ -128,8 +134,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 					}
 					else
 					{
+						inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
 						log_message( log_module, MSG_DEBUG,"Not all the data was written to %s:%d. Asked len : %d, written len %d\n",
-								inet_ntoa(actual_client->SocketAddr.sin_addr),
+								addr_buf,
 								actual_client->SocketAddr.sin_port,
 								actual_channel->nb_bytes,
 								written_len);
@@ -168,8 +176,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 
 					if(!actual_client->consecutive_errors)
 					{
+						inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
 						log_message( log_module, MSG_DETAIL,"Error when writing to client %s:%d : %s\n",
-								inet_ntoa(actual_client->SocketAddr.sin_addr),
+								addr_buf,
 								actual_client->SocketAddr.sin_port,
 								strerror(errno));
 						gettimeofday (&tv, (struct timezone *) NULL);
@@ -182,8 +192,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 						gettimeofday (&tv, (struct timezone *) NULL);
 						if((unicast_vars->consecutive_errors_timeout > 0) && (tv.tv_sec - actual_client->first_error_time) > unicast_vars->consecutive_errors_timeout)
 						{
-							log_message( log_module, MSG_INFO,"Consecutive errors when writing to client %s:%d during too much time, we disconnect\n",
-									inet_ntoa(actual_client->SocketAddr.sin_addr),
+							inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
+							log_message(log_module, MSG_INFO, "Consecutive errors when writing to client %s:%d during too much time, we disconnect\n",
+									addr_buf,
 									actual_client->SocketAddr.sin_port);
 							temp_client=actual_client->chan_next;
 							unicast_close_connection(unicast_vars,actual_client->Socket);
@@ -196,8 +208,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 					//data successfully written
 					if (actual_client->consecutive_errors)
 					{
+						inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
 						log_message( log_module, MSG_DETAIL,"We can write again to client %s:%d\n",
-								inet_ntoa(actual_client->SocketAddr.sin_addr),
+								addr_buf,
 								actual_client->SocketAddr.sin_port);
 						actual_client->consecutive_errors=0;
 						actual_client->last_write_error=0;
@@ -221,8 +235,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 						else //queue now empty
 						{
 							packets_left=0;
+							inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+
 							log_message( log_module, MSG_DEBUG,"The queue is now empty :) client %s:%d \n",
-									inet_ntoa(actual_client->SocketAddr.sin_addr),
+									addr_buf,
 									actual_client->SocketAddr.sin_port);
 						}
 					}
@@ -364,7 +380,3 @@ int unicast_queue_requeue(unicast_queue_header_t *header, unsigned char *data, i
 	header->data_bytes_in_queue += data_len;
 	return 0;
 }
-
-
-
-

--- a/src/unicast_queue.c
+++ b/src/unicast_queue.c
@@ -66,7 +66,7 @@ void unicast_close_connection(unicast_parameters_t *unicast_vars, int Socket);
  */
 void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *unicast_vars)
 {
-	char addr_buf[64] = { 0, };
+	char addr_buf[IPV6_CHAR_LEN] = { 0, };
 
 	if(actual_channel->clients)
 	{
@@ -97,11 +97,9 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 					if(!actual_client->queue.full)
 					{
 						actual_client->queue.full=1;
-						inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+						socket_to_string(actual_client->Socket, addr_buf, sizeof(addr_buf));
 
-						log_message(log_module, MSG_DETAIL, "The queue is full, we now throw away new packets for client %s:%d\n",
-								addr_buf,
-								actual_client->SocketAddr.sin_port);
+						log_message(log_module, MSG_DETAIL, "The queue is full, we now throw away new packets for client %s\n", addr_buf);
 					}
 				}
 				buffer=unicast_queue_get_data(&actual_client->queue, &buffer_len);
@@ -122,11 +120,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 					{
 						if(errno != actual_client->last_write_error)
 						{
-							inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+							socket_to_string(actual_client->Socket, addr_buf, sizeof(addr_buf));
 
-							log_message(log_module, MSG_DEBUG, "New error when writing to client %s:%d : %s\n",
+							log_message(log_module, MSG_DEBUG, "New error when writing to client %s : %s\n",
 									addr_buf,
-									actual_client->SocketAddr.sin_port,
 									strerror(errno));
 							actual_client->last_write_error=errno;
 							written_len=0;
@@ -134,11 +131,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 					}
 					else
 					{
-						inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+						socket_to_string(actual_client->Socket, addr_buf, sizeof(addr_buf));
 
-						log_message( log_module, MSG_DEBUG,"Not all the data was written to %s:%d. Asked len : %d, written len %d\n",
+						log_message( log_module, MSG_DEBUG,"Not all the data was written to %s. Asked len : %d, written len %d\n",
 								addr_buf,
-								actual_client->SocketAddr.sin_port,
 								actual_channel->nb_bytes,
 								written_len);
 					}
@@ -176,11 +172,10 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 
 					if(!actual_client->consecutive_errors)
 					{
-						inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+						socket_to_string(actual_client->Socket, addr_buf, sizeof(addr_buf));
 
-						log_message( log_module, MSG_DETAIL,"Error when writing to client %s:%d : %s\n",
+						log_message( log_module, MSG_DETAIL,"Error when writing to client %s : %s\n",
 								addr_buf,
-								actual_client->SocketAddr.sin_port,
 								strerror(errno));
 						gettimeofday (&tv, (struct timezone *) NULL);
 						actual_client->first_error_time = tv.tv_sec;
@@ -192,11 +187,9 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 						gettimeofday (&tv, (struct timezone *) NULL);
 						if((unicast_vars->consecutive_errors_timeout > 0) && (tv.tv_sec - actual_client->first_error_time) > unicast_vars->consecutive_errors_timeout)
 						{
-							inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+							socket_to_string(actual_client->Socket, addr_buf, sizeof(addr_buf));
 
-							log_message(log_module, MSG_INFO, "Consecutive errors when writing to client %s:%d during too much time, we disconnect\n",
-									addr_buf,
-									actual_client->SocketAddr.sin_port);
+							log_message(log_module, MSG_INFO, "Consecutive errors when writing to client %s during too much time, we disconnect\n", addr_buf);
 							temp_client=actual_client->chan_next;
 							unicast_close_connection(unicast_vars,actual_client->Socket);
 							actual_client=temp_client;
@@ -208,11 +201,9 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 					//data successfully written
 					if (actual_client->consecutive_errors)
 					{
-						inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+						socket_to_string(actual_client->Socket, addr_buf, sizeof(addr_buf));
 
-						log_message( log_module, MSG_DETAIL,"We can write again to client %s:%d\n",
-								addr_buf,
-								actual_client->SocketAddr.sin_port);
+						log_message(log_module, MSG_DETAIL, "We can write again to client %s\n", addr_buf);
 						actual_client->consecutive_errors=0;
 						actual_client->last_write_error=0;
 						if(data_from_queue)
@@ -235,11 +226,9 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 						else //queue now empty
 						{
 							packets_left=0;
-							inet_ntop(AF_INET, &actual_client->SocketAddr.sin_addr, addr_buf, sizeof(addr_buf));
+							socket_to_string(actual_client->Socket, addr_buf, sizeof(addr_buf));
 
-							log_message( log_module, MSG_DEBUG,"The queue is now empty :) client %s:%d \n",
-									addr_buf,
-									actual_client->SocketAddr.sin_port);
+							log_message(log_module, MSG_DEBUG, "The queue is now empty :) client %s\n", addr_buf);
 						}
 					}
 				}

--- a/src/unicast_queue.c
+++ b/src/unicast_queue.c
@@ -110,7 +110,7 @@ void unicast_data_send(mumudvb_channel_t *actual_channel, unicast_parameters_t *
 			while(packets_left>0)
 			{
 				//we send the data
-				written_len=send(actual_client->Socket,buffer, buffer_len,MSG_NOSIGNAL);
+				written_len=send(actual_client->Socket,(const char *)buffer, buffer_len,MSG_NOSIGNAL);
 				//We check if all the data was successfully written
 				if(written_len<buffer_len)
 				{

--- a/src/unicast_queue.c
+++ b/src/unicast_queue.c
@@ -29,8 +29,10 @@
  */
 
 #include <errno.h>
+#ifndef _WIN32
 #include <sys/time.h>
 #include <unistd.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include "unicast_http.h"

--- a/src/unicast_queue.c
+++ b/src/unicast_queue.c
@@ -28,10 +28,14 @@
  * @date 2009-2010
  */
 
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <errno.h>
 #ifndef _WIN32
 #include <sys/time.h>
 #include <unistd.h>
+#else
+#include <process.h> /* for getpid() */
 #endif
 #include <string.h>
 #include <stdlib.h>

--- a/src/win32.c
+++ b/src/win32.c
@@ -1,0 +1,118 @@
+#include <windows.h>
+#include <time.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "win32.h"
+
+#if _MSC_VER < 1800
+#undef va_copy
+#define va_copy(dst, src) (dst = src)
+#endif
+
+#if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
+#define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
+#else
+#define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
+#endif
+
+struct timezone
+{
+    int  tz_minuteswest; /* minutes W of Greenwich */
+    int  tz_dsttime;     /* type of dst correction */
+};
+
+int gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+    FILETIME ft;
+    unsigned __int64 tmpres = 0;
+    static int tzflag = 0;
+
+    if (NULL != tv) {
+        GetSystemTimeAsFileTime(&ft);
+
+        tmpres |= ft.dwHighDateTime;
+        tmpres <<= 32;
+        tmpres |= ft.dwLowDateTime;
+
+        tmpres /= 10;  /*convert into microseconds*/
+        /*converting file time to unix epoch*/
+        tmpres -= DELTA_EPOCH_IN_MICROSECS;
+        tv->tv_sec = (long)(tmpres / 1000000UL);
+        tv->tv_usec = (long)(tmpres % 1000000UL);
+    }
+
+    return 0;
+}
+
+int vasprintf(char **strp, const char *fmt, va_list ap)
+{
+    va_list ap_copy;
+    int formattedLength, actualLength;
+    size_t requiredSize;
+
+    // be paranoid
+    *strp = NULL;
+
+    // copy va_list, as it is used twice
+    va_copy(ap_copy, ap);
+
+    // compute length of formatted string, without NULL terminator
+    formattedLength = _vscprintf(fmt, ap_copy);
+    va_end(ap_copy);
+
+    // bail out on error
+    if (formattedLength < 0) {
+        return -1;
+    }
+
+    // allocate buffer, with NULL terminator
+    requiredSize = ((size_t)formattedLength) + 1;
+    *strp = (char *)malloc(requiredSize);
+
+    // bail out on failed memory allocation
+    if (*strp == NULL) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    // write formatted string to buffer, use security hardened _s function
+    actualLength = vsnprintf_s(*strp, requiredSize, requiredSize - 1, fmt, ap);
+
+    // again, be paranoid
+    if (actualLength != formattedLength) {
+        free(*strp);
+        *strp = NULL;
+        errno = EOTHER;
+        return -1;
+    }
+
+    return formattedLength;
+}
+
+int asprintf(char **strp, const char *fmt, ...)
+{
+    int result;
+
+    va_list ap;
+    va_start(ap, fmt);
+    result = vasprintf(strp, fmt, ap);
+    va_end(ap);
+
+    return result;
+}
+
+void usleep(unsigned int usec)
+{
+    HANDLE timer;
+    LARGE_INTEGER ft;
+
+    ft.QuadPart = -(10 * (__int64)usec);
+
+    timer = CreateWaitableTimer(NULL, TRUE, NULL);
+    if (timer) {
+        SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
+        WaitForSingleObject(timer, INFINITE);
+        CloseHandle(timer);
+    }
+}

--- a/src/win32.c
+++ b/src/win32.c
@@ -18,12 +18,6 @@
 #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
 
-struct timezone
-{
-    int  tz_minuteswest; /* minutes W of Greenwich */
-    int  tz_dsttime;     /* type of dst correction */
-};
-
 int gettimeofday(struct timeval *tv, struct timezone *tz)
 {
     FILETIME ft;

--- a/src/win32.c
+++ b/src/win32.c
@@ -3,6 +3,8 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
 #include "win32.h"
 
 #if _MSC_VER < 1800

--- a/src/win32.h
+++ b/src/win32.h
@@ -1,0 +1,5 @@
+#pragma once
+
+int gettimeofday(struct timeval *tv, struct timezone *tz);
+int asprintf(char **strp, const char *fmt, ...);
+void usleep(unsigned int usec);

--- a/src/win32.h
+++ b/src/win32.h
@@ -1,5 +1,11 @@
 #pragma once
 
+struct timezone
+{
+    int  tz_minuteswest; /* minutes W of Greenwich */
+    int  tz_dsttime;     /* type of dst correction */
+};
+
 int gettimeofday(struct timeval *tv, struct timezone *tz);
 int asprintf(char **strp, const char *fmt, ...);
 void usleep(unsigned int usec);


### PR DESCRIPTION
This is kind of a huge PR because I took the project hoping to test some multicast/unicast streaming but as most of my devices are under Windows, I wanted to make it work there first.

At first, I tried using mingw to build stuff, and that made some progress, but as I was looking over the code, I noticed not much of it was actually platform-dependent other than DVB layer, so a native win32 build looked promising.

A *lot* of these changes are whitespace changes because my editor will REMOVE trailing whitespace on lines by default, and this project was riddled with them. Honestly I think anything larger than a quick hack should have some kind of consistent indent/spacing style automatically applied to prevent this kind of thing from happening.

Changes are, as the title says

1) Making build on win32
2) removing a bunch of compiler warnings (ambigious casts, usage of obsolete inet apis, operator order parenthesis, unused variables, etc etc)
3) Allow building without dvb-api at all - in that case, the only input method is file, at least on Linux, on win32 there's also an interprocess named pipe input method (see doc/readme.win32 for explanation)

All of the above, while still maintaining a buildable environment under Linux (tested to the best of my knowledge)

This would probably need a fair bit of review to chug through the whitespace changes, but as far as I know most other modifications are legit and do not change /break existing functionality.

Comments welcome.