### PR TITLE
Fixing up some issues left over from windows build, and a pass at compiler warnings cleanup

### DIFF
--- a/src/autoconf_atsc.c
+++ b/src/autoconf_atsc.c
@@ -205,11 +205,12 @@ int autoconf_parse_vct_channel(unsigned char *buf, auto_p_t *auto_p, mumu_chan_p
 #endif
 	char utf8_short_name[15];
 	char *channel_name=NULL;
-	char long_name[MAX_NAME_LEN];
+#ifdef HAVE_LIBUCSI
+	char long_name[MAX_NAME_LEN] = { 0, };
+#endif
 
 	int mpeg2_service_type=0;
 	vct_channel=(psip_vct_channel_t *)buf;
-	long_name[0]='\0';
 
 	// *********** We get the channel short name *******************
 	memcpy (unconverted_short_name, vct_channel->short_name, 14*sizeof(uint8_t));

--- a/src/log.c
+++ b/src/log.c
@@ -166,11 +166,12 @@ int read_logging_configuration(stats_infos_t *stats_infos, char *substring)
 	else if (!strcmp (substring, "log_file"))
 	{
 		substring = strtok (NULL, delimiteurs);
-		log_params.log_file_path=malloc((strlen(substring)+1)*sizeof(char));
-		strncpy(log_params.log_file_path,substring,strlen(substring)+1);
+		if (log_params.log_file_path != NULL)
+			free(log_params.log_file_path);
+		log_params.log_file_path = strdup(substring);
 		if(log_params.log_file_path==NULL)
 		{
-			log_message(log_module,MSG_WARN,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
+			log_message(log_module,MSG_WARN,"Problem with strdup : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
 			return -1;
 		}
 	}
@@ -179,13 +180,12 @@ int read_logging_configuration(stats_infos_t *stats_infos, char *substring)
 		substring = strtok (NULL,"=" );
 		if(log_params.log_header!=NULL)
 			free(log_params.log_header);
-		log_params.log_header=malloc((strlen(substring)+1)*sizeof(char));
+		log_params.log_header = strdup(substring);
 		if(log_params.log_header==NULL)
 		{
-			log_message(log_module,MSG_WARN,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
+			log_message(log_module,MSG_WARN,"Problem with strdup : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
 			return -1;
 		}
-		sprintf(log_params.log_header,"%s",substring);
 	}
 	else if (!strcmp (substring, "log_flush_interval"))
 	{
@@ -457,7 +457,7 @@ void log_streamed_channels(char *log_module,int number_of_channels, mumudvb_chan
 				log_message( log_module,  MSG_INFO, "\tUnicast : Channel accessible directly via %s:%d\n",unicastipOut, channels[curr_channel].unicast_port);
 		}
 		mumu_string_t string=EMPTY_STRING;
-		char lang[5];
+		char lang[6];
 		if(set_interrupted(mumu_string_append(&string, "        pids : ")))return;
 		for (curr_pid = 0; curr_pid < channels[curr_channel].pid_i.num_pids; curr_pid++)
 		{

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -350,7 +350,7 @@ typedef struct mumudvb_channel_t{
 	/**the channel name*/
 	char user_name[MAX_NAME_LEN];
 	char name[MAX_NAME_LEN];
-	mumu_f_t name_f; /* MU_F_T(name); */
+	MU_F_T(name)
 	char service_name[MAX_NAME_LEN];
 
 	/* The PID information for this channel*/
@@ -359,12 +359,10 @@ typedef struct mumudvb_channel_t{
 	/** The service Type from the SDT */
 	int service_type;
 	/**Transport stream ID*/
-	int service_id;
-	mumu_f_t service_id_f; /* MU_F_V(int,service_id); */
+	MU_F_V(int,service_id)
 
 	/**Say if we need to ask this channel to the cam*/
-	int need_cam_ask;
-	mumu_f_t need_cam_ask_f; /* MU_F_V(int,need_cam_ask); */
+	MU_F_V(int,need_cam_ask)
 	/** When did we asked the channel to the CAM */
 	long cam_asking_time;
 	/**The ca system ids*/
@@ -453,7 +451,7 @@ typedef struct mumudvb_channel_t{
 	char ip4Out[20];
 	MU_F_T(ip4Out)
 	/**The multicast port*/
-	MU_F_V(int,portOut)
+	MU_F_V(int, portOut)
 	/**The multicast output socket*/
 	struct sockaddr_in sOut4;
 	/**The multicast output socket*/
@@ -478,7 +476,7 @@ typedef struct mumudvb_channel_t{
 
 	/**The sap playlist group*/
 	char sap_group[SAP_GROUP_LENGTH];
-	mumu_f_t sap_group_f; /* MU_F_T(sap_group); */
+	MU_F_T(sap_group)
 	//do we need to update the SAP announce (typically a name change)
 	int sap_need_update;
 

--- a/src/mumudvb_common.c
+++ b/src/mumudvb_common.c
@@ -237,6 +237,8 @@ int string_comput(char *string)
 		len=pluspos-string;
 	}
 	tempchar=malloc(sizeof(char)*(len+1));
+	if (tempchar == NULL)
+		return 0;
 	strncpy(tempchar,string,len);
 	tempchar[len]='\0';
 	number1=string_mult(tempchar);

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -119,13 +119,12 @@ void parse_cmd_line(int argc, char **argv,char *(*conf_filename),tune_p_t *tune_
 		switch (c)
 		{
 		case 'c':
-		*conf_filename = (char *) malloc (strlen (optarg) + 1);
-		if (!*conf_filename)
-		{
-			log_message( log_module, MSG_ERROR,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
-			exit(ERROR_MEMORY);
-		}
-		strncpy (*conf_filename, optarg, strlen (optarg) + 1);
+			*conf_filename = strdup(optarg);
+			if (!*conf_filename)
+			{
+				log_message( log_module, MSG_ERROR,"Problem with strdup : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
+				exit(ERROR_MEMORY);
+			}
 		break;
 		case 'a':
 			tune_p->card=atoi(optarg);
@@ -156,13 +155,12 @@ void parse_cmd_line(int argc, char **argv,char *(*conf_filename),tune_p_t *tune_
 			*listingcards=1;
 			break;
 		case 'z':
-			*dump_filename = (char *) malloc (strlen (optarg) + 1);
+			*dump_filename = strdup(optarg);
 			if (!*dump_filename)
 			{
-				log_message( log_module, MSG_ERROR,"Problem with malloc : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
+				log_message( log_module, MSG_ERROR,"Problem with strdup : %s file : %s line %d\n",strerror(errno),__FILE__,__LINE__);
 				exit(ERROR_MEMORY);
 			}
-			strncpy (*dump_filename, optarg, strlen (optarg) + 1);
 			log_message( log_module, MSG_WARN,"You've decided to dump the received stream into %s. Be warned, it can grow quite fast", *dump_filename);
 			break;
 		default: /* -Wswitch-default */

--- a/src/ts.c
+++ b/src/ts.c
@@ -864,9 +864,9 @@ void ts_display_satellite_delivery_system_descriptor(char* log_module, unsigned 
 		log_message( log_module, MSG_FLOOD, "Estern position");
 	else
 		log_message( log_module, MSG_FLOOD, "Western position");
+	log_message(log_module, MSG_FLOOD, "Polarization: (0x%02x)", descr->polarization);
 	switch(descr->polarization)
 	{
-	log_message( log_module, MSG_FLOOD, "Polarization: (0x%02x)", descr->polarization);
 	case 0:
 		log_message( log_module, MSG_FLOOD, "Polarization: linear - horizontal");
 		break;

--- a/src/tune.c
+++ b/src/tune.c
@@ -1304,7 +1304,7 @@ int check_status(int fd_frontend,int type,uint32_t lo_frequency, int display_str
 				log_message( log_module,  MSG_INFO, "Event:  Frequency: %d\n",parameters.frequency);
 				break;
 			case FE_QPSK:
-				log_message( log_module,  MSG_INFO, "Event:  Frequency: %d (or %d)\n",(unsigned int)((parameters.frequency)+lo_frequency),(unsigned int) abs((parameters.frequency)-lo_frequency));
+				log_message( log_module,  MSG_INFO, "Event:  Frequency: %d (or %d)\n",(unsigned int)((parameters.frequency)+lo_frequency),(unsigned int) abs((int)parameters.frequency-(int)lo_frequency));
 				log_message( log_module,  MSG_INFO, "        SymbolRate: %d\n",parameters.u.qpsk.symbol_rate);
 				log_message( log_module,  MSG_INFO, "        FEC_inner:  %d\n",parameters.u.qpsk.fec_inner);
 				break;
@@ -1537,7 +1537,7 @@ default:
 				lo_frequency=tuneparams->lnb_lof_standard;
 			}
 
-			feparams.frequency=abs(tuneparams->freq-lo_frequency);
+			feparams.frequency=abs((int)tuneparams->freq-(int)lo_frequency);
 
 
 			log_message( log_module,  MSG_INFO, "Tuning DVB-S to Freq: %u kHz, Transp frequency: %f , LO frequency %u kHz  Pol:%c Srate=%d, LNB number: %d\n",

--- a/src/unicast_monit.c
+++ b/src/unicast_monit.c
@@ -39,6 +39,9 @@
 #include "tune.h"
 #include "rewrite.h"
 #include "autoconf.h"
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
 #ifdef ENABLE_CAM_SUPPORT
 #include "cam.h"
 #endif


### PR DESCRIPTION
This is slightly smaller than the last one :)

I've replaced MU_F_T/MU_F_V back to where they were before windows build patch - an extra ; was giving hell to msvc compiler but happily ignored by gcc.

Also replaced a bunch of malloc/strncpy patterns with strdup. Can't imagine any system made in the last 10+ years where strdup wasn't available, and it gets rid of a bunch of build warnings related to strncpy safety.