### PR TITLE
Fix 100% CPU load due to wrong logic during device poll

### DIFF
--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -1398,7 +1398,7 @@ int main (int argc, char **argv)
 		else
 		{
 			/* Poll the open file descriptors : we wait for data*/
-			if (fds.fd_source != 0) {
+			if (fds.fd_source == 0) {
 #ifndef _WIN32
 				poll_ret = mumudvb_poll(fds.pfds, fds.pfdsnum, DVB_POLL_TIMEOUT);
 #else


### PR DESCRIPTION
Found in issue #292 