### PR TITLE
Fix compiler warnings and update WIN32 build after merging HLS code

### DIFF
--- a/MuMuDVB.vcxproj
+++ b/MuMuDVB.vcxproj
@@ -132,6 +132,7 @@
     </ClCompile>
     <ClCompile Include="src\dvb_win32.c" />
     <ClCompile Include="src\getopt.c" />
+    <ClCompile Include="src\hls.c" />
     <ClCompile Include="src\log.c" />
     <ClCompile Include="src\multicast.c" />
     <ClCompile Include="src\mumudvb.c" />

--- a/MuMuDVB.vcxproj.filters
+++ b/MuMuDVB.vcxproj.filters
@@ -135,6 +135,9 @@
     <ClCompile Include="src\dvb_win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\hls.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\autoconf.h">

--- a/src/log.c
+++ b/src/log.c
@@ -32,6 +32,7 @@
 
 #define _POSIX_C_SOURCE 200809L
 #define _CRT_SECURE_NO_WARNINGS
+#define _CRT_NONSTDC_NO_DEPRECATE
 
 #include <stdio.h>
 #include <string.h>

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -213,7 +213,7 @@ int main (int argc, char **argv)
 	pthread_t cardthread;
 
 	pthread_t monitorthread = pthread_self();
-  pthread_t hlsthread;
+	pthread_t hlsthread = pthread_self();
 	card_thread_parameters_t cardthreadparams;
 	memset(&cardthreadparams,0,sizeof(card_thread_parameters_t));
 

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -8,6 +8,7 @@
 #define _GNU_SOURCE		//in order to use program_invocation_short_name and pthread_timedjoin_np
 #define _POSIX
 #define _CRT_SECURE_NO_WARNINGS
+#define _CRT_NONSTDC_NO_DEPRECATE
 
 #include "config.h"
 
@@ -266,7 +267,7 @@ int mumudvb_close(int no_daemon,
 			log_message(log_module,MSG_WARN,"Monitor Thread badly closed: %s\n", strerror(iRet));
 	}
 
-	if(*hlsthread)
+	if(!pthread_equal(*hlsthread, pthread_self()))
 	{
 		log_message(log_module,MSG_DEBUG,"HLS Thread closing\n");
 		hls_thread_params->threadshutdown=1;

--- a/src/ts.h
+++ b/src/ts.h
@@ -37,6 +37,10 @@
 #include <endian.h>
 #endif
 
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define __BIG_ENDIAN__
+#endif
+
 #include "config.h"
 
 //The maximum size for a TS packet
@@ -191,30 +195,30 @@ typedef struct {
 } ts_header_t;
 
 typedef struct {
-  u_char adaptation_field_length		:8;
+  uint8_t adaptation_field_length		:8;
 #ifdef __BIG_ENDIAN__
-  u_char adaptation_field_extension_flag	:1;
-  u_char transport_private_data_flag		:1;
-  u_char splicing_point_flag			:1;
-  u_char OPCR_flag				:1;
-  u_char PCR_flag				:1;
-  u_char elementary_stream_priority_indicator	:1;
-  u_char random_access_indicator		:1;
-  u_char discontinuity_indicator		:1;
+  uint8_t adaptation_field_extension_flag	:1;
+  uint8_t transport_private_data_flag		:1;
+  uint8_t splicing_point_flag			:1;
+  uint8_t OPCR_flag				:1;
+  uint8_t PCR_flag				:1;
+  uint8_t elementary_stream_priority_indicator	:1;
+  uint8_t random_access_indicator		:1;
+  uint8_t discontinuity_indicator		:1;
 #else
-  u_char discontinuity_indicator		:1;
-  u_char random_access_indicator		:1;
-  u_char elementary_stream_priority_indicator	:1;
-  u_char PCR_flag				:1;
-  u_char OPCR_flag				:1;
-  u_char splicing_point_flag			:1;
-  u_char transport_private_data_flag		:1;
-  u_char adaptation_field_extension_flag	:1;
+  uint8_t discontinuity_indicator		:1;
+  uint8_t random_access_indicator		:1;
+  uint8_t elementary_stream_priority_indicator	:1;
+  uint8_t PCR_flag				:1;
+  uint8_t OPCR_flag				:1;
+  uint8_t splicing_point_flag			:1;
+  uint8_t transport_private_data_flag		:1;
+  uint8_t adaptation_field_extension_flag	:1;
 #endif
   char PCR[6];
   char OPCR[6];
   char splice_countdown				:8;
-  u_char transport_private_data_length		:8;
+  uint8_t transport_private_data_length		:8;
 } af_header_t;
 
 //For cam support and autoconfigure

--- a/src/win32.c
+++ b/src/win32.c
@@ -1,3 +1,4 @@
+#define _WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <time.h>
 #include <errno.h>
@@ -5,6 +6,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <direct.h>
 #include "win32.h"
 
 #if _MSC_VER < 1800
@@ -111,4 +113,33 @@ void usleep(unsigned int usec)
         WaitForSingleObject(timer, INFINITE);
         CloseHandle(timer);
     }
+}
+
+void sleep(unsigned int sec)
+{
+    usleep(sec * 1000000);
+}
+
+int mkpath(char *file_path, unsigned int mode)
+{
+    char *p = file_path;
+    (void)mode;
+
+    while (*p != '\0') {
+        p++;
+
+        while (*p != '\0' && *p != '/')
+            p++;
+
+        char v = *p;
+        *p = '\0';
+
+        if (_mkdir(file_path) == -1 && errno != EEXIST) {
+            *p = v;
+            return -1;
+        }
+        *p = v;
+    }
+
+    return 0;
 }

--- a/src/win32.h
+++ b/src/win32.h
@@ -9,3 +9,5 @@ struct timezone
 int gettimeofday(struct timeval *tv, struct timezone *tz);
 int asprintf(char **strp, const char *fmt, ...);
 void usleep(unsigned int usec);
+void sleep(unsigned int sec);
+int mkpath(char *file_path, unsigned int mode);


### PR DESCRIPTION
Update ts.h to use uint8_t and add endian-detecting code (should work on gcc)
Implement win32-specific mkpath() version - needs testing still, in case a path with a drive letter is provided