### PR TITLE
Fix broken linux build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ fi
 
 # Checks for programs.
 AC_PROG_CC
+AC_PROG_CC_STDC
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 

--- a/src/unicast_monit.c
+++ b/src/unicast_monit.c
@@ -639,7 +639,6 @@ int unicast_send_channel_list_xml (int number_of_channels, mumudvb_channel_t *ch
 #ifndef ENABLE_SCAM_SUPPORT
     (void) scam_vars_v; //to make compiler happy
 #else
-    char *scam_vars;
     scam_parameters_t *scam_vars=(scam_parameters_t *)scam_vars_v;
 #endif
 


### PR DESCRIPTION
loop initial declarations are only allowed in C99 or C11 mode (broken by 82b962af8feab5a85ebef5f1142ecd49461a69b9)
error: conflicting types for scam_vars