### PR TITLE
Add (optional) support for ARIB STD-B24 charset decoding, and additional configure options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ dnl
 dnl cam support
 dnl
 AC_ARG_ENABLE(cam_support,
-  [  --enable-cam-support          CAM support (default enabled)],,[enable_cam_support="yes"])
+  [  --enable-cam-support    CAM support (default enabled)],,[enable_cam_support="yes"])
 
 if test "${enable_cam_support}" = "yes"
 then
@@ -57,10 +57,34 @@ fi
 AM_CONDITIONAL(BUILD_CAMSUPPORT, [test "${enable_cam_support}" != "no"])
 
 dnl
+dnl arib support
+dnl
+AC_ARG_ENABLE(arib_support,
+  [  --enable-arib-support   ARIB charset support (default enabled)],,[enable_arib_support="yes"])
+
+if test "${enable_arib_support}" = "yes"
+then
+  AC_CHECK_HEADER([aribb24/aribb24.h], [], [enable_arib_support="no"])
+  if test "${enable_arib_support}" != "no"
+  then
+    AC_CHECK_LIB([aribb24], [arib_instance_new], [], [enable_arib_support="no"])
+  fi
+  if test "${enable_arib_support}" != "no"
+  then
+    AC_DEFINE(ENABLE_ARIB_SUPPORT, 1, Define if you want the ARIB charset support)
+  else
+    AC_MSG_WARN([libaribb24 is needed for ARIB charset support])
+  fi
+else
+  enable_arib_support="no"
+fi
+AM_CONDITIONAL(BUILD_ARIB_SUPPORT, [test "${enable_arib_support}" != "no"])
+
+dnl
 dnl scam support
 dnl
 AC_ARG_ENABLE(scam_support,
-  [  --enable-scam-support          SCAM support (default enabled)],,[enable_scam_support="yes"])
+  [  --enable-scam-support   SCAM support (default enabled)],,[enable_scam_support="yes"])
 
 if test "${enable_scam_support}" = "yes"
 then
@@ -92,7 +116,7 @@ dnl
 dnl duma support
 dnl
 AC_ARG_ENABLE(duma,
-  [  --enable-duma          Debbuging DUMA library (default disabled)],,
+  [  --enable-duma           Debbuging DUMA library (default disabled)],,
   [enable_duma="no"])
 
 if test "${enable_duma}" = "yes"
@@ -107,7 +131,7 @@ then
 fi
 
 AC_ARG_ENABLE(android,
-  [  --enable-android          Build for android (default disabled)],,[enable_android="no"])
+  [  --enable-android        Build for android (default disabled)],,[enable_android="no"])
 
 if test "${enable_android}" = "yes"
 then
@@ -115,7 +139,7 @@ then
 fi
 
 AC_ARG_ENABLE(tune_old,
-  [  --enable-tune_old          Use old code for tuning (default disabled)],,[enable_tune_old="no"])
+  [  --enable-tune_old       Use old code for tuning (default disabled)],,[enable_tune_old="no"])
 
 if test "${enable_tune_old}" = "yes"
 then
@@ -165,6 +189,12 @@ if test "${atsc_long_names}" = "yes" ; then
         echo "Build with ATSC long names support:                 yes"
 else
         echo "Build with ATSC long names support:                  no"
+fi
+
+if test "${enable_arib_support}" != "no" ; then
+        echo "Build with ARIB charset support:                    yes"
+else
+        echo "Build with ARIB charset support:                     no"
 fi
 
 if test "${enable_android}" = "yes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -7,15 +7,6 @@ AC_CONFIG_SRCDIR([src/mumudvb.c])
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([src/config.h])
 
-dnl
-dnl Check for linux dvb api headers
-dnl
-AC_CHECK_HEADER([linux/dvb/dmx.h])
-if test "$ac_cv_header_linux_dvb_dmx_h" = no; then
-        AC_MSG_WARN([linux dvb api headers not found, disabling dvb api functionality])
-        AC_DEFINE(DISABLE_DVB_API, 1, Define if you want to bulid without DVB API)
-fi
-
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CC_STDC
@@ -27,6 +18,22 @@ dnl Iconv stuff
 dnl
 AM_ICONV
 
+dnl
+dnl dvb-api support (disable on request or check existence of header)
+dnl
+AC_ARG_ENABLE(dvb_support,
+  [  --enable-dvb-support    linux dvb-api support (default enabled)],,[enable_dvb_support="yes"])
+if test "${enable_dvb_support}" = "yes"
+then
+  AC_CHECK_HEADER([linux/dvb/dmx.h])
+  if test "$ac_cv_header_linux_dvb_dmx_h" = no; then
+    AC_MSG_WARN([linux dvb api headers not found, disabling dvb api functionality])
+    AC_DEFINE(DISABLE_DVB_API, 1, Define if you want to bulid without DVB API)
+  fi
+else
+  enable_dvb_support="no"
+  AC_DEFINE(DISABLE_DVB_API, 1, Define if you want to bulid without DVB API)
+fi
 
 AC_CHECK_LIB([dvbapi], [dvbdemux_set_section_filter])
 AC_CHECK_LIB([ucsi], [atsc_text_segment_decode],[atsc_long_names="yes"], [atsc_long_names="no"])
@@ -172,6 +179,12 @@ echo "MuMuDVB configure results:"
 echo ""
 echo "Features"
 echo ""
+
+if test "${enable_dvb_support}" != "no" ; then
+        echo "Build with Linux DVB-API support:                   yes"
+else
+        echo "Build with Linux DVB-API support:                    no"
+fi
 
 if test "${enable_cam_support}" != "no" ; then
         echo "Build with CAM support:                             yes"

--- a/doc/README.asciidoc
+++ b/doc/README.asciidoc
@@ -67,6 +67,7 @@ Features overview
 - Software descrambling through oscam dvbapi and libdvbcsa
 - Flexible configuration mechanism using templates
 - Support for embedded platforms based on UCLIBC and ANDROID
+- Support for UDP unicast/multicast input in the absense of a DVB card
 
 
 Installation
@@ -105,9 +106,11 @@ The `[configure options]` specific to MuMuDVB are:
 ---------------------------------------------------------------------
   --enable-cam-support    CAM support (default enabled)
   --enable-scam-support   SCAM support (default enabled) (see note below)
+  --enable-arib-support   Build support for ARIB STD-B24 character decoding (specific to ISDB-T in Japan)
   --enable-coverage       build for test coverage (default disabled)
   --enable-duma           Debbuging DUMA library (default disabled)
   --enable-android        Support for Android (default disabled)
+  --disable-dvb-support   Build without Linux DVB-API support, even on systems where the headers are present
 ---------------------------------------------------------------------
 
 [NOTE]
@@ -125,6 +128,9 @@ In the case of fedora, the dvb-apps package does not contains the headers, you h
 
 [NOTE]
 The SCAM support depends on libdvbcsa from videolan. The configure script will detect automatically the presence of these libraries and deactivate the SCAM support if one of them is not present. It needs also trunk version of oscam to get control words. Oscam configuration is described below in section concerning software descrambling v2 inside mumudvb. 
+
+[NOTE]
+The ARIB STD-B24 support depends on libaribb24. The configure script will automatically detect it's presence and enable `--japan` runtime option to enable character set translation.
 
 [NOTE]
 The decoding of long channel names for autoconfiguration in ATSC depends on libucsi (from linuxtv's dvb-apps). The configure script will detect automatically the presence of this library and deactivate the long channel name support if it is not present. The full autoconfiguration will still work with ATSC but the channel names will be the short channels names (7 characters maximum)
@@ -186,6 +192,9 @@ Possible options are:
 
 --server_id
 	The server id (for autoconfiguration, overrided by the configuration file)
+
+-j, --japan
+	Enable support for decoding ARIB STD-B24 character encoding in SI/EPG (only if built with libaribb24 support)
 
 -h, --help
 	Show help

--- a/src/config_win32.h
+++ b/src/config_win32.h
@@ -7,6 +7,9 @@
 /* Define if you want to bulid without DVB API */
 #define DISABLE_DVB_API 1
 
+/* Define if you want the ARIB charset support */
+/* #undef ENABLE_ARIB_SUPPORT */
+
 /* Define if you want the CAM support */
 /* #undef ENABLE_CAM_SUPPORT */
 

--- a/src/log.c
+++ b/src/log.c
@@ -65,6 +65,13 @@
 #include <iconv.h>
 #endif
 
+#ifdef ENABLE_ARIB_SUPPORT
+#include <aribb24/aribb24.h>
+#include <aribb24/decoder.h>
+
+static int convert_arib_string(char *string, int max_len);
+#endif
+
 #ifdef ENABLE_CAM_SUPPORT
 #include <libdvben50221/en50221_errno.h>
 #endif
@@ -1014,6 +1021,9 @@ void usage (char *name)
 			"-v           : More verbose\n"
 			"-q           : Less verbose\n"
 			"--dumpfile   : Debug option : Dump the stream into the specified file\n"
+#ifdef ENABLE_ARIB_SUPPORT
+			"-j --japan   : Enable processing ARIB encoding in SI/EPG data\n"
+#endif
 			"-h, --help   : Help\n"
 			"\n", name);
 	print_info ();
@@ -1061,6 +1071,9 @@ char *encodings_en300468[] ={
 		"GB2312",    //control char 0x13
 		"BIG5",      //control char 0x14
 		"ISO-10646/UTF8",      //control char 0x15
+#ifdef ENABLE_ARIB_SUPPORT
+		"ARIB STB-B24", // 0x16 actually a HACK since Japan does not follow EN 300 468 encodings
+#endif
 };
 
 /**@brief Convert text according to EN 300 468 annex A
@@ -1068,6 +1081,10 @@ char *encodings_en300468[] ={
  */
 int convert_en300468_string(char *string, int max_len, int debug)
 {
+#if ENABLE_ARIB_SUPPORT
+	if (japan_active)
+		return convert_arib_string(string, max_len);
+#endif
 
 	int encoding_control_char=8; //cf encodings_en300468
 	char *tempdest, *tempbuf;
@@ -1222,6 +1239,60 @@ exit_iconv:
 
 	return encoding_control_char;
 }
+
+#ifdef ENABLE_ARIB_SUPPORT
+static arib_instance_t *p_instance = NULL;
+
+/* decode JIS 8-bit character to UTF-8 characters. */
+static char *decode_aribstring(arib_instance_t *p_instance, const unsigned char *psz_instring)
+{
+	if (!psz_instring)
+		return NULL;
+	size_t i_in = strlen((const char *)psz_instring);
+
+	arib_decoder_t *p_decoder = arib_get_decoder(p_instance);
+	if (!p_decoder)
+		return NULL;
+
+	size_t i_out = i_in * 4;
+	char *psz_outstring = (char *)calloc(i_out + 1, sizeof(char));
+
+	arib_initialize_decoder(p_decoder);
+	i_out = arib_decode_buffer(p_decoder, psz_instring, i_in, psz_outstring, i_out);
+	arib_finalize_decoder(p_decoder);
+
+	return psz_outstring;
+}
+
+static int convert_arib_string(char *string, int max_len)
+{
+	static bool init = false;
+	char *p_out = NULL;
+
+	if (!init) {
+		p_instance = arib_instance_new(NULL);
+		if (!p_instance)
+			return -1;
+		init = true;
+	}
+
+	p_out = decode_aribstring(p_instance, (const unsigned char *)string);
+	if (p_out) {
+		printf("converted shitty string %s to %s\n", string, p_out);
+		strncpy(string, p_out, max_len);
+		free(p_out);
+		return 0x16; /* Hack to index into encodings_en300468[] table */
+	}
+
+	return -1;
+}
+
+void close_arib_instance(void)
+{
+	if (p_instance)
+		arib_instance_destroy(p_instance);
+}
+#endif
 
 /** @brief : show the contents of the CA identifier descriptor
  *

--- a/src/log.c
+++ b/src/log.c
@@ -1278,7 +1278,6 @@ static int convert_arib_string(char *string, int max_len)
 
 	p_out = decode_aribstring(p_instance, (const unsigned char *)string);
 	if (p_out) {
-		printf("converted shitty string %s to %s\n", string, p_out);
 		strncpy(string, p_out, max_len);
 		free(p_out);
 		return 0x16; /* Hack to index into encodings_en300468[] table */

--- a/src/log.h
+++ b/src/log.h
@@ -127,6 +127,9 @@ int read_logging_configuration(stats_infos_t *stats_infos, char *substring);
 void sync_logs();
 char *running_status_to_str(int running_status);
 int convert_en300468_string(char *string, int max_len, int debug);
+#ifdef ENABLE_ARIB_SUPPORT
+void close_arib_instance(void);
+#endif
 void show_CA_identifier_descriptor(unsigned char *buf);
 char *ready_f_to_str(chan_status_t flag);
 #endif

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -177,9 +177,10 @@ int  write_streamed_channels=1;
 /** Do we send scrambled packets ? */
 int dont_send_scrambled=0;
 
-
-
-
+#ifdef ENABLE_ARIB_SUPPORT
+/* special flag for arib charset handling, unfortunately because japan, this has to be global and special-cased */
+bool japan_active = false;
+#endif
 
 //logging
 extern log_params_t log_params;

--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -606,6 +606,9 @@ typedef struct mumu_string_t{
 extern bool t2mi_active;
 extern bool t2mi_first;
 extern int t2_partial_size;
+#ifdef ENABLE_ARIB_SUPPORT
+extern bool japan_active;
+#endif
 
 int mumu_string_append(mumu_string_t *string, const char *psz_format, ...);
 void mumu_free_string(mumu_string_t *string);

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -89,12 +89,15 @@ extern int tuning_no_diff;
 
 void parse_cmd_line(int argc, char **argv,char *(*conf_filename),tune_p_t *tune_p,stats_infos_t *stats_infos,int *server_id, int *no_daemon,char **dump_filename, int *listingcards)
 {
-	const char short_options[] = "c:sdthvql";
+	const char short_options[] = "c:sdthjvql";
 	const struct option long_options[] = {
 			{"config", required_argument, NULL, 'c'},
 			{"signal", no_argument, NULL, 's'},
 			{"traffic", no_argument, NULL, 't'},
 			{"server_id", required_argument, NULL, 'i'},
+#ifdef ENABLE_ARIB_SUPPORT
+			{"japan", no_argument, NULL, 'j'},
+#endif
 			{"debug", no_argument, NULL, 'd'},
 			{"help", no_argument, NULL, 'h'},
 			{"list-cards", no_argument, NULL, 'l'},
@@ -137,6 +140,11 @@ void parse_cmd_line(int argc, char **argv,char *(*conf_filename),tune_p_t *tune_
 		case 'i':
 			*server_id = atoi(optarg);
 			break;
+#ifdef ENABLE_ARIB_SUPPORT
+		case 'j':
+			japan_active = true;
+			break;
+#endif
 		case 't':
 			stats_infos->show_traffic = 1;
 			break;
@@ -302,6 +310,11 @@ int mumudvb_close(int no_daemon,
 
 
 	}
+
+#ifdef ENABLE_ARIB_SUPPORT
+	/* Close ARIB B24 decoder instance */
+	close_arib_instance();
+#endif
 
 	// we close the file descriptors
 	close_card_fd(fds);


### PR DESCRIPTION
For users of mumudvb in Japan, which does not follow the EN 300 468 character set encodings (and does not use UTF-8) I added an option to convert SI/EPG strings by using `libaribb24`. This is automatically detected but can be controlled by `--enable-arib-support` or `--disable-arib-support` configure option. Once built in, it is required to use `-j` or `--japan` to further enable this conversion. There is no simple way to auto-detect Japan-specific TS so it is better to allow user to specify this option by command line. This is similar to how `tsDuck` etc does it.

With proper conversion, Japanese ISDB streams look correct in channel list and during debug output:
```
Info:  Autoconf:  Diffusion 3 channels
Info:  Autoconf:  Channel number :   0,   service id 56360  name : "ＴＶＱ九州放送１"
Info:  Autoconf:        Multicast4 ip : :0
Info:  Autoconf:        Unicast : Channel accessible via the master connection, 0.0.0.0:4242
Info:  Autoconf:  Channel number :   1,   service id 56361  name : "ＴＶＱ九州放送２"
Info:  Autoconf:        Multicast4 ip : :0
Info:  Autoconf:        Unicast : Channel accessible via the master connection, 0.0.0.0:4242
Info:  Autoconf:  Channel number :   2,   service id 56744  name : "ＴＶＱ九州放送携帯"
Info:  Autoconf:        Multicast4 ip : :0
Info:  Autoconf:        Unicast : Channel accessible via the master connection, 0.0.0.0:4242
```
![image](https://user-images.githubusercontent.com/4640472/170658296-0c61e56a-0cdd-4478-bd8e-8ff21cbc2339.png)

I've also implemented `--disable-dvb-support` to allow building without any DVB-API support, even on systems with kernel headers. This allows using mumudvb strictly as UDP/Multicast input.

If someone could test building this and see if it works, that would be great.
Some example ISDB-T streams are here: https://tsduck.io/streams/?name=japan-dttv
