### PR TITLE
[autoconf_pmt] Fix parsing outside PMT descriptors buffer

### DIFF
--- a/src/autoconf_pmt.c
+++ b/src/autoconf_pmt.c
@@ -86,7 +86,7 @@ void autoconf_get_pmt_pids(auto_p_t *auto_p, mumudvb_ts_packet_t *pmt, int *pids
 	//search in the main loop
 	if(program_info_length > 0)
 	{
-		while(len = pmt_find_descriptor(0x09,pmt->data_full+PMT_LEN,PMT_LEN+program_info_length,&pos),len)
+		while(len = pmt_find_descriptor(0x09,pmt->data_full+PMT_LEN,program_info_length,&pos),len)
 		{
 			log_message( log_module,  MSG_FLOOD,"  Found a CA descr in main loop at pos %d", pos);
 


### PR DESCRIPTION
`program_info_length` specifies "the number of bytes of the descriptors" but mumudvb unnecessarily increases that value by `PMT_LEN` causing it to search for a given descriptor outside the descriptors buffer.

For example, in my case, the current behaviour is as follows (after adding some custom debugging):

```
program info length 11
>>> descriptors_loop_len: 23
descriptors_loop_len: 23
descriptor tag: 12, length: 4
descriptors_loop_len: 17
descriptor tag: 14, length: 3
descriptors_loop_len: 12
descriptor tag: 27, length: 254
<<< descr 0x9 not found
```

As you can see, the descriptors buffer is assumed to be 23 bytes whereas `program_info_length` says it's only 11 bytes. As a result a 3rd, non-existent, descriptor is found (tag: 27) where PMT should have only 2 descriptors (tags: 12 and 14):
![image](https://user-images.githubusercontent.com/13220781/213144970-5d549a3c-efb0-4201-9a9a-f77392e0fce8.png)

That 3rd descriptor detected by mumudvb (tag: 27, length: 254) is, in fact, a program element/component with stream type = 27, which you can see in the image above (analysis done by [DVBInspector](https://github.com/EricBerendsen/dvbinspector))

After applying my PR the behaviour changes to:

```
program info length 11
>>> descriptors_loop_len: 11
descriptors_loop_len: 11
descriptor tag: 12, length: 4
descriptors_loop_len: 5
descriptor tag: 14, length: 3
<<< descr 0x9 not found
```
(only 2 descriptors detected)

I've also checked other `pmt_find_descriptor` usages and they are all OK - none of them add anything to the buffer length value.