### PR TITLE
Include service_type 0x20 for UHD TV streams.

### DIFF
--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -459,6 +459,7 @@ void autoconf_update_chan_status(auto_p_t *auto_p,mumu_chan_p_t *chan_p)
 				chan_p->channels[ichan].service_type==0x16||
 				chan_p->channels[ichan].service_type==0x19||
 				chan_p->channels[ichan].service_type==0x1f||
+				chan_p->channels[ichan].service_type==0x20||
 				chan_p->channels[ichan].service_type==0xc0)||
 				((chan_p->channels[ichan].service_type==0x02||
 						chan_p->channels[ichan].service_type==0x0a)&&auto_p->autoconf_radios))


### PR DESCRIPTION
Add 0x20 service_type for UHD TV streams.  Tested with France 2 UHD and Test UHD on french DVB-T2 498 MHz.