### PR TITLE
fix -std=c23 build failure

### DIFF
--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -131,10 +131,7 @@ We cannot discover easily the MTU with unconnected UDP
 
 #define SAP_GROUP_LENGTH 20
 
-/** define bool for plain C code **/
-#ifndef __cplusplus
-    typedef enum { false = 0, true = !false } bool;
-#endif
+#include <stdbool.h>
 
 enum
 {


### PR DESCRIPTION
gcc-15 switched to -std=c23 by default:

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212

As a result `mumudvb` fails the build so only typedef int bool for __STDC_VERSION__ <= 201710L (C17)

```
    ../../src/mumudvb.h:136:47: error: expected ';', identifier or '(' before 'bool'
      136 |     typedef enum { false = 0, true = !false } bool;
          |                                               ^~~~
```