### PR TITLE
FIX 6->7 MP2T in RTP

### DIFF
--- a/src/mumudvb.h
+++ b/src/mumudvb.h
@@ -102,7 +102,7 @@ We cannot discover easily the MTU with unconnected UDP
 
 7*188 plus margin
  */
-#define MAX_UDP_SIZE 1320
+#define MAX_UDP_SIZE 1350
 
 /**the max mandatory pid number*/
 #define MAX_MANDATORY_PID_NUMBER   32


### PR DESCRIPTION
I noticed that 7 * 188 = 1316 bytes  and 12 bytes for the RTP Header doesn't fit into the MAX_UDP_SIZE. I would propose to increase MAX_UDP_SIZE. This is still inside the MTU. This causes MuMuDVB to pack 7 TS packets instead of 6 into the RTP payload. This is far more common, as far as I know.