### PR TITLE
fix wrong continuity counter modulo

### DIFF
--- a/src/rewrite_pat.c
+++ b/src/rewrite_pat.c
@@ -255,7 +255,7 @@ void pat_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_
 	}
 	//To avoid the duplicates, we have to update the continuity counter
 	rewrite_vars->pat_continuity_counter++;
-	rewrite_vars->pat_continuity_counter= rewrite_vars->pat_continuity_counter % 32;
+	rewrite_vars->pat_continuity_counter= rewrite_vars->pat_continuity_counter % 16;
 }
 
 

--- a/src/rewrite_pmt.c
+++ b/src/rewrite_pmt.c
@@ -212,7 +212,7 @@ int pmt_channel_rewrite(mumudvb_channel_t *channel) {
 int pmt_send_packet(unsigned char *pmt_ts_packet, mumudvb_channel_t *channel) {
 	//Everything is good, send the generated packet
 	channel->pmt_continuity_counter++;
-	channel->pmt_continuity_counter = channel->pmt_continuity_counter % 32;
+	channel->pmt_continuity_counter = channel->pmt_continuity_counter % 16;
 	memcpy(pmt_ts_packet, channel->generated_pmt, TS_PACKET_SIZE);
 	set_continuity_counter(pmt_ts_packet, channel->pmt_continuity_counter);
 	return 1;

--- a/src/rewrite_sdt.c
+++ b/src/rewrite_sdt.c
@@ -388,7 +388,7 @@ int sdt_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t
 	}
 	//To avoid the duplicates, we have to update the continuity counter
 	rewrite_vars->sdt_continuity_counter++;
-	rewrite_vars->sdt_continuity_counter= rewrite_vars->sdt_continuity_counter % 32;
+	rewrite_vars->sdt_continuity_counter= rewrite_vars->sdt_continuity_counter % 16;
 	return 0;
 }
 


### PR DESCRIPTION
This PR doesn't change what happens, because the [compiler](https://stackoverflow.com/questions/4908300/overflow-in-bit-fields) already does module on the continuity counter bitfield in the ts_header_t struct. `  uint8_t continuity_counter                     :4;`
Still i propose to correct the modulo value.
