### PR TITLE
option to override config directives, init scripts, small fix

### DIFF
--- a/scripts/alpine/apkbuild_example/APKBUILD
+++ b/scripts/alpine/apkbuild_example/APKBUILD
@@ -1,0 +1,67 @@
+# Contributor: [anp/hsw] <sysop@880.ru>
+# Maintainer: Only You <you_and@you.again>
+pkgname=mumudvb
+_pkgname=MuMuDVB
+pkgver=20260714
+pkgrel=99
+pkgdesc="A DVB IPTV streaming software"
+url="https://github.com/braice/MuMuDVB"
+arch="all"
+license="GPL-2.0-or-later"
+makedepends="automake autoconf libtool linux-headers m4 libdvbcsa-dev asciidoc gettext-dev"
+
+## select desired source and get new commit hash from github here:
+#gitcommit="46056b21f790603dfb38ca5c39be84c92f32d99e"
+#source="$pkgname-$gitcommit.zip::https://github.com/braice/MuMuDVB/archive/$gitcommit.zip"
+#gitcommit="5a457a797db20ef00e4db5536b0a6872930cfd75"
+#source="$pkgname-$gitcommit.zip::https://github.com/anphsw/MuMuDVB/archive/$gitcommit.zip"
+
+subpackages="$pkgname-doc
+	$pkgname-openrc:openrc_stuff
+"
+install="$pkgname.pre-install"
+pkgusers="mumudvb"
+
+builddir="$srcdir/MuMuDVB-$gitcommit"
+
+prepare() {
+	libtoolize --force
+	aclocal && autoheader
+	automake --force-missing --add-missing
+	autoreconf -i -f
+}
+
+build() {
+	./configure --prefix=/usr
+	make
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+	mkdir -p "$pkgdir"/var/run/mumudvb
+	chown $pkgusers "$pkgdir"/var/run/mumudvb
+	mkdir -p "$pkgdir"/etc/$pkgname
+}
+
+doc() {
+	pkgdesc="$pkgname documentation"
+	_docdir="configuration_examples diagrams html transcode"
+	cd "$builddir"/doc
+	make doc
+	mkdir -p "$subpkgdir"/usr/share/doc/$pkgname
+	for doc in $_docdir; do
+		mv $doc "$subpkgdir"/usr/share/doc/$pkgname
+	done
+}
+
+openrc_stuff() {
+        pkgdesc="A DVB IPTV streaming software (OpenRC init scripts)"
+        depends=openrc
+        install_if="openrc $pkgname"
+
+	install -Dm755 "$builddir"/scripts/alpine/etc/init.d/$pkgname "$subpkgdir"/etc/init.d/$pkgname
+	install -Dm644 "$builddir"/scripts/alpine/etc/conf.d/$pkgname "$subpkgdir"/etc/conf.d/$pkgname
+}
+
+sha512sums="
+"

--- a/scripts/alpine/apkbuild_example/mumudvb.pre-install
+++ b/scripts/alpine/apkbuild_example/mumudvb.pre-install
@@ -1,0 +1,4 @@
+#!/bin/sh
+adduser -S -H -h /var/run/mumudvb -s /sbin/nologin -g mumudvb mumudvb 2>/dev/null
+adduser mumudvb video
+exit 0

--- a/scripts/alpine/etc/conf.d/mumudvb
+++ b/scripts/alpine/etc/conf.d/mumudvb
@@ -1,0 +1,11 @@
+# override default config on /etc/mumudvb/mumudvb.conf (for single instance)
+# You can check config file examples in -doc package
+#CONFIG_FILE="/etc/mumudvb/mumudbv_card${ADAPTER}.conf"
+
+# additional config options can be specified from command line:
+#COMMAND_ARGS="-o tuner=3 -o hls=1"
+
+# for multiple instances:
+# "ln -s mumudvb mumudvb.name_here"
+# instance config file: ${MUMUDVB_DIR}/$instance_name
+#MUMUDVB_DIR="/etc/mumudvb"

--- a/scripts/alpine/etc/init.d/mumudvb
+++ b/scripts/alpine/etc/init.d/mumudvb
@@ -1,0 +1,45 @@
+#!/sbin/openrc-run
+
+command="/usr/bin/mumudvb"
+command_background="true"
+daemonuser="mumudvb"
+
+instance_name=${RC_SVCNAME#*.}
+pidfile="/run/mumudvb/${instance_name}.pid"
+
+if [ "$instance_name" != "${RC_SVCNAME}" ]
+then
+    name="MuMuDVB ($instance_name)"
+else
+    name="MuMuDVB"
+fi
+
+: ${cfgdir:=${MUMUDVBDIR:-"/etc/mumudvb"}}
+: ${cfgfile:=${CONFIG_FILE:-"$cfgdir/$instance_name.conf"}}
+
+start_pre() {
+	if [ ! -f "$cfgfile" ] ; then
+		eerror "You need to setup $cfgfile first. Install $pkgname-doc for examples"
+		return 1
+	fi
+
+        checkpath --directory --owner ${daemonuser} --mode 0755 "/run/mumudvb"
+}
+
+depend() {
+        need net
+        after firewall
+}
+
+start() {
+        ebegin "Starting $name"
+		start-stop-daemon --start --name mumudvb_$ADAPTER \
+        	--user $daemonuser --exec $command -- -c $cfgfile $COMMAND_ARGS -o filename_pid=$pidfile
+        eend $?
+}
+
+stop() {
+        ebegin "Stopping $name"
+        start-stop-daemon --stop --pidfile $pidfile
+        eend $?
+}

--- a/src/autoconf.c
+++ b/src/autoconf.c
@@ -57,7 +57,7 @@
 
 #ifndef _WIN32
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <unistd.h>
 #endif
 

--- a/src/cam.c
+++ b/src/cam.c
@@ -37,7 +37,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <sys/stat.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 /* DVB Card Drivers */
 #include <linux/dvb/version.h>

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -37,7 +37,7 @@
 #ifndef _WIN32
 #include <syslog.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <resolv.h>
 #include <unistd.h>
 #endif

--- a/src/log.c
+++ b/src/log.c
@@ -1012,6 +1012,7 @@ void usage (char *name)
 			"It's main feature is to take a whole transponder and put each channel on a different multicast IP.\n\n"
 			"Usage: %s [options] \n"
 			"-c, --config : Config file\n"
+			"-o           : Override config option from command line (-o name=value)\n"
 			"-s, --signal : Display signal power\n"
 			"-t, --traffic : Display channels traffic\n"
 			"-l, --list-cards : List the DVB cards and exit\n"

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -96,7 +96,7 @@
 #include <ctype.h>
 #ifndef _WIN32
 #include <sys/time.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/epoll.h>
 #include <resolv.h>
 #include <syslog.h>

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -196,6 +196,17 @@ void chan_new_pmt(unsigned char *ts_packet, mumu_chan_p_t *chan_p, int pid);
 
 int processt2(unsigned char* input_buf, unsigned int input_buf_offset, unsigned char* output_buf, unsigned int output_buf_offset, unsigned int output_buf_size, uint8_t plpId);
 
+char *cmdline_get_override(int *idx, char *current_line, int argc, char **argv) {
+    while (idx && *idx < argc - 1) {
+	(*idx)++;
+	if (strlen(argv[*idx - 1]) == 2 && !memcmp(argv[*idx - 1], "-o", 2)) {
+	    log_message(log_module, MSG_DEBUG, "Override from command line: %s\n", argv[*idx]);
+	    return strcpy(current_line, argv[*idx]);
+	}
+    }
+    return NULL;
+}
+
 int main (int argc, char **argv)
 {
 	// file descriptors
@@ -421,8 +432,12 @@ int main (int argc, char **argv)
 	int curr_channel_old=-1;
 	// we scan config file
 	// see doc/README_CONF* for further information
+	int arg_pos=0;
+	uintptr_t cfg_parsing_flag = 2;
 	int line_len;
-	while (fgets (current_line, CONF_LINELEN, conf_file))
+	while (cfg_parsing_flag > 1 ?
+		(cfg_parsing_flag = (uintptr_t)fgets (current_line, CONF_LINELEN, conf_file) + 1) :
+		(uintptr_t)cmdline_get_override(&arg_pos, current_line, argc, argv))
 	{
 		//We suppress the end of line (this can disturb atoi if there is spaces at the end of the line)
 		//Thanks to Pierre Gronlier pierre.gronlier at gmail.com for finding that bug

--- a/src/mumudvb_channels.c
+++ b/src/mumudvb_channels.c
@@ -34,7 +34,7 @@
 #include "unicast_http.h"
 
 #ifndef _WIN32
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 #endif
 #include <errno.h>

--- a/src/mumudvb_common.c
+++ b/src/mumudvb_common.c
@@ -33,7 +33,7 @@
 #include "unicast_http.h"
 
 #ifndef _WIN32
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 #endif
 #include <errno.h>

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -89,7 +89,7 @@ extern int tuning_no_diff;
 
 void parse_cmd_line(int argc, char **argv,char *(*conf_filename),tune_p_t *tune_p,stats_infos_t *stats_infos,int *server_id, int *no_daemon,char **dump_filename, int *listingcards)
 {
-	const char short_options[] = "c:sdthjvql";
+	const char short_options[] = "c:sdthjvqlo:";
 	const struct option long_options[] = {
 			{"config", required_argument, NULL, 'c'},
 			{"signal", no_argument, NULL, 's'},
@@ -164,6 +164,8 @@ void parse_cmd_line(int argc, char **argv,char *(*conf_filename),tune_p_t *tune_
 		case 'l':
 			*listingcards=1;
 			break;
+		case 'o':
+			break; // will be parsed by cmdline_get_override()
 		case 'z':
 			*dump_filename = strdup(optarg);
 			if (!*dump_filename)

--- a/src/mumudvb_mon.c
+++ b/src/mumudvb_mon.c
@@ -18,7 +18,7 @@
 #include <ctype.h>
 #ifndef _WIN32
 #include <sys/time.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/stat.h>
 #include <resolv.h>
 #include <syslog.h>

--- a/src/tune.c
+++ b/src/tune.c
@@ -39,7 +39,7 @@
 #include <ctype.h>
 #ifndef _WIN32
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <unistd.h>
 #endif
 #include "config.h"


### PR DESCRIPTION
- option to override config directives from command line (-o parameter=value). Required for init scripts (custom pid file name, dirs, etc).
- init scripts for alpine/gentoo/other distributions with openrc
- example build script for alpine linux build system
- fix sys/poll.h -> poll.h for POSIX compatibility
